### PR TITLE
perf: first-row type caching for Records path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+```python
+from rustpy_xlsxwriter import FastExcel
+
+# Minimal code to reproduce the issue
+```
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages or tracebacks if applicable.
+
+## Environment
+
+- **Python version**: `python --version`
+- **rustpy-xlsxwriter version**: `python -c "from rustpy_xlsxwriter import get_version; print(get_version())"`
+- **OS**: (e.g. Ubuntu 24.04, macOS 15, Windows 11)
+- **Data source**: (Records / Pandas / Polars)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Description
+
+A clear description of the feature you'd like.
+
+## Use Case
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed API
+
+```python
+# How would you like to use this feature?
+```
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+-
+
+## Type
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Performance improvement
+- [ ] Documentation
+- [ ] Refactoring
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] `pytest tests/ -m "not benchmark"` passes
+- [ ] `cargo check` has no warnings
+- [ ] Type stubs (`.pyi`) updated if API changed
+- [ ] README updated if applicable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+## Project Overview
+
+RustPy-XlsxWriter is a high-performance Excel file generation library for Python, powered by Rust via PyO3. It achieves ~7-9x faster performance than Python's xlsxwriter.
+
+## Build & Development
+
+```bash
+# Development build
+maturin develop
+
+# Release build (with LTO)
+maturin develop --release
+
+# Production wheel
+maturin build --release
+```
+
+## Testing
+
+```bash
+# Unit tests only (fast, ~1 second)
+pytest tests/ -m "not benchmark"
+
+# All tests including benchmarks (~8 minutes)
+pytest tests/
+
+# Run benchmarks with codspeed
+pytest tests/test_benchmark.py --codspeed
+
+# Standalone benchmark script
+python benchmark.py
+```
+
+## Project Structure
+
+```
+src/
+├── lib.rs              # PyO3 module entry point
+├── worksheet.rs        # Core write logic (Records, Pandas, Polars, Arrow)
+├── arrow_writer.rs     # Arrow zero-copy batch writer
+├── data_types.rs       # WorksheetData enum (ArrowStream, Records, Pandas, Polars)
+├── metadata.rs         # Package metadata functions
+└── utils.rs            # Sheet name validation
+
+rustpy_xlsxwriter/
+├── __init__.py         # FastExcel builder class + Python API
+└── rustpy_xlsxwriter.pyi  # Type stubs for IDE support
+
+tests/
+├── conftest.py            # Shared fixtures
+├── test_metadata.py       # Package metadata
+├── test_validation.py     # Sheet name validation
+├── test_write_single.py   # Single sheet writing
+├── test_write_multi.py    # Multiple sheets
+├── test_write_functional.py # Functional API
+├── test_freeze_panes.py   # Freeze panes
+├── test_password.py       # Password protection
+├── test_bytesio.py        # In-memory buffer
+├── test_dataframe.py      # Pandas DataFrame
+├── test_polars.py         # Polars DataFrame
+├── test_styling.py        # Float/datetime format, bold headers
+└── test_benchmark.py      # Performance benchmarks
+```
+
+## Key Architecture
+
+- **Data input detection** (`data_types.rs`): `__arrow_c_stream__` → Arrow zero-copy, `get_column` → Polars fallback, `columns` → Pandas fallback, else → Records (list of dicts / generator)
+- **Arrow path**: Uses `pyo3-arrow` + `arrow-array` to read DataFrame memory directly in Rust — no Python object conversion
+- **Records path**: First-row type caching — detect column types from row 1, use fast single-cast dispatch for subsequent rows
+- **Constant memory mode**: All paths write row-by-row for `rust_xlsxwriter` constant memory compatibility
+- **Format caching**: `Format` objects created once, reused across all cells
+
+## Dependencies
+
+- `pyo3` 0.28 — Rust-Python bindings
+- `rust_xlsxwriter` 0.93 — Excel file generation (constant_memory, ryu, zlib)
+- `pyo3-arrow` 0.17 + `arrow-array` 58 — Arrow zero-copy for DataFrames
+- `indexmap` — Ordered maps for deterministic sheet ordering
+
+## Coding Conventions
+
+- Propagate all write errors with `.map_err(xlsx_err)?` — never use `let _ =`
+- Check `PyBool` before `PyInt` (Python bool is subclass of int)
+- Use `value.cast::<T>()` for Python native types, `value.extract::<T>()` for numpy scalar fallback
+- Use `chars().count()` not `len()` for Unicode string length validation
+- Keep `write_py_any_bound` and `write_py_any_bound_detect` in sync — they share the same type cascade logic
+- Tests must verify actual cell content via `openpyxl`, not just file existence
+
+## Version Bumping
+
+Update version in both:
+1. `Cargo.toml` → `version = "x.y.z"`
+2. `rustpy_xlsxwriter/rustpy_xlsxwriter.pyi` → `get_version()` docstring example

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at **rahmadafandiii@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to RustPy-XlsxWriter
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.8+
+- Rust (latest stable)
+- [maturin](https://github.com/PyO3/maturin)
+
+### Setup
+
+```bash
+git clone https://github.com/rahmadafandi/rustpy-xlsxwriter.git
+cd rustpy-xlsxwriter
+python -m venv .venv
+source .venv/bin/activate
+pip install maturin
+pip install -e ".[tests]"
+```
+
+### Build
+
+```bash
+# Development (fast compile, no optimizations)
+maturin develop
+
+# Release (optimized, LTO — slower compile)
+maturin develop --release
+```
+
+### Run Tests
+
+```bash
+# Unit tests only (~1 second)
+pytest tests/ -m "not benchmark"
+
+# All tests including benchmarks
+pytest tests/
+
+# Benchmark
+python benchmark.py
+```
+
+## Project Structure
+
+```
+src/                          # Rust source
+├── lib.rs                   # PyO3 module entry point
+├── worksheet.rs             # Core write logic
+├── arrow_ffi.rs             # Arrow C Data Interface bridge
+├── arrow_writer.rs          # Arrow RecordBatch writer
+├── data_types.rs            # Input type detection
+├── metadata.rs              # Package metadata
+└── utils.rs                 # Validation utilities
+
+rustpy_xlsxwriter/           # Python package
+├── __init__.py              # FastExcel class
+└── rustpy_xlsxwriter.pyi    # Type stubs
+
+tests/                       # Test suite (86 tests)
+examples/                    # 13 runnable examples
+```
+
+## How to Contribute
+
+### Reporting Bugs
+
+- Open an [issue](https://github.com/rahmadafandi/rustpy-xlsxwriter/issues/new?template=bug_report.md)
+- Include Python version, OS, and a minimal reproduction
+
+### Suggesting Features
+
+- Open an [issue](https://github.com/rahmadafandi/rustpy-xlsxwriter/issues/new?template=feature_request.md)
+- Describe the use case and expected behavior
+
+### Pull Requests
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Make your changes
+4. Add tests for new functionality
+5. Run `pytest tests/ -m "not benchmark"` and ensure all tests pass
+6. Run `cargo check` to ensure no Rust warnings
+7. Commit with a descriptive message
+8. Push and open a Pull Request
+
+### Coding Guidelines
+
+**Rust:**
+- Propagate errors with `.map_err(xlsx_err)?` — never use `let _ =`
+- Check `PyBool` before `PyInt` (Python bool is subclass of int)
+- Keep `write_py_any_bound` and `write_py_any_bound_detect` in sync
+- Use `chars().count()` for Unicode string length
+
+**Python:**
+- Follow PEP 8
+- Update `.pyi` type stubs when changing the Python API
+
+**Tests:**
+- Verify actual cell content via `openpyxl`, not just file existence
+- Use `tmp_path` fixture for temporary files
+
+### Version Bumping
+
+Update in both files:
+1. `Cargo.toml` — `version = "x.y.z"`
+2. `rustpy_xlsxwriter/rustpy_xlsxwriter.pyi` — `get_version()` docstring

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3ccafdf54c050be48a3a086d372f77ba6615f5057211607cd30e5ac5cec6d"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -688,18 +688,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972720a441c91fd9c49f212a1d2d74c6e3803b231ebc8d66c51efbd7ccab11c8"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5994456d9dab8934d600d3867571b6410f24fbd6002570ad56356733eb54859b"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ce9cc8d81b3c4969748807604d92b4eef363c5bb82b1a1bdb34ec6f1093a18"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf4b60036a154d23282679b658e3cc7d88d3b8c9a40b43824785f232d2e1b98"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "rustpy-xlsxwriter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
- "chrono-tz",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
@@ -63,28 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-cast"
-version = "58.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "atoi",
- "base64",
- "chrono",
- "comfy-table",
- "half",
- "lexical-core",
- "num-traits",
- "ryu",
-]
-
-[[package]]
 name = "arrow-data"
 version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,19 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-ord"
-version = "58.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
-]
-
-[[package]]
 name = "arrow-schema"
 version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,39 +84,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-select"
-version = "58.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
-]
-
-[[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -194,30 +129,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
-dependencies = [
- "chrono",
- "phf",
-]
-
-[[package]]
-name = "comfy-table"
-version = "7.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
-dependencies = [
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]
@@ -393,63 +306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,16 +356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,21 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
 ]
 
 [[package]]
@@ -578,45 +409,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "numpy"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
-dependencies = [
- "half",
- "libc",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits",
- "pyo3",
- "pyo3-build-config",
- "rustc-hash",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
-
-[[package]]
-name = "phf"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pkg-config"
@@ -629,15 +425,6 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -654,8 +441,6 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
- "chrono",
- "chrono-tz",
  "indexmap",
  "libc",
  "once_cell",
@@ -663,27 +448,6 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
-]
-
-[[package]]
-name = "pyo3-arrow"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0360400036dda3db3d69102ef7e9646e4cd946c75a2d1d41fb8fd39879312636"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "chrono",
- "chrono-tz",
- "half",
- "indexmap",
- "numpy",
- "pyo3",
- "thiserror",
 ]
 
 [[package]]
@@ -746,12 +510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "rust_xlsxwriter"
 version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,12 +519,6 @@ dependencies = [
  "tempfile",
  "zip",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -789,7 +541,6 @@ dependencies = [
  "arrow-schema",
  "indexmap",
  "pyo3",
- "pyo3-arrow",
  "rust_xlsxwriter",
 ]
 
@@ -816,12 +567,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "syn"
@@ -854,26 +599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,18 +618,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "rustpy-xlsxwriter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ name = "rustpy_xlsxwriter"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow-array = "58.0.0"
-arrow-schema = "58.0.0"
+arrow-array = { version = "58.0.0", features = ["ffi"] }
+arrow-schema = { version = "58.0.0", features = ["ffi"] }
 indexmap = "2.8.0"
 pyo3 = { version = "0.28.2", features = ["extension-module", "indexmap"] }
-pyo3-arrow = "0.17.0"
 rust_xlsxwriter = { version = "0.93.0", features = ["constant_memory", "ryu", "zlib"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpy-xlsxwriter"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Rahmad Afandi <rahmadafandiii@gmail.com>"]
 description = "Rust Python bindings for rust_xlsxwriter"
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 arrow-array = "58.0.0"
 arrow-schema = "58.0.0"
 indexmap = "2.8.0"
-pyo3 = { version = "0.28.0", features = ["extension-module", "indexmap"] }
+pyo3 = { version = "0.28.2", features = ["extension-module", "indexmap"] }
 pyo3-arrow = "0.17.0"
 rust_xlsxwriter = { version = "0.93.0", features = ["constant_memory", "ryu", "zlib"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpy-xlsxwriter"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Rahmad Afandi <rahmadafandiii@gmail.com>"]
 description = "Rust Python bindings for rust_xlsxwriter"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ with FastExcel("output.xlsx") as f:
 
 ## Features
 
-- **~7.3x–9.0x faster** than Python's xlsxwriter
+- **~7.3x–9.4x faster** than Python's xlsxwriter
 - Fluent builder API via `FastExcel` class
 - Context manager support (`with` statement) for auto-save
 - Support for `str`, `int`, `float`, `bool`, `None`, `datetime` values
@@ -280,22 +280,22 @@ Benchmarked via [`benchmark.py`](benchmark.py) (`python benchmark.py`):
 
 | Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
 | --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~2.95s             | ~26.67s           | **9.0x faster**  |
-| 1,000,000 | ~5.86s             | ~52.36s           | **8.9x faster**  |
+| 500,000   | ~2.89s             | ~27.32s           | **9.4x faster**  |
+| 1,000,000 | ~5.74s             | ~52.81s           | **9.2x faster**  |
 
 ### Pandas DataFrame (Arrow zero-copy)
 
 | Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
 | --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~1.18s             | ~9.01s            | **7.6x faster**  |
-| 1,000,000 | ~2.36s             | ~18.00s           | **7.6x faster**  |
+| 500,000   | ~1.19s             | ~9.10s            | **7.7x faster**  |
+| 1,000,000 | ~2.36s             | ~19.25s           | **8.2x faster**  |
 
 ### Polars DataFrame (Arrow zero-copy)
 
 | Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
 | --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~1.18s             | ~8.63s            | **7.3x faster**  |
-| 1,000,000 | ~2.35s             | ~17.21s           | **7.3x faster**  |
+| 500,000   | ~1.33s             | ~10.30s           | **7.7x faster**  |
+| 1,000,000 | ~2.34s             | ~17.12s           | **7.3x faster**  |
 
 ### Key optimizations
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 [![Downloads](https://pepy.tech/badge/rustpy-xlsxwriter)](https://pepy.tech/project/rustpy-xlsxwriter)
 [![CI](https://github.com/rahmadafandi/rustpy-xlsxwriter/actions/workflows/CI.yml/badge.svg)](https://github.com/rahmadafandi/rustpy-xlsxwriter/actions/workflows/CI.yml)
 
-RustPy-XlsxWriter is a high-performance library for generating Excel files in Python, powered by Rust and integrated using PyO3. This library is ideal for creating Excel files with large datasets efficiently while maintaining a simple and Pythonic interface.
+High-performance Excel file generation for Python, powered by Rust. **~7x-9x faster** than [XlsxWriter](https://github.com/jmcnamara/XlsxWriter) with a simple, Pythonic API.
+
+```python
+from rustpy_xlsxwriter import FastExcel
+
+FastExcel("report.xlsx").sheet("Sheet1", records).save()
+```
 
 ## Installation
 
@@ -14,193 +20,117 @@ RustPy-XlsxWriter is a high-performance library for generating Excel files in Py
 pip install rustpy-xlsxwriter
 ```
 
+## Performance
+
+Benchmarked via [`benchmark.py`](benchmark.py) — run `python benchmark.py` to reproduce:
+
+| Input type | Records | RustPy-XlsxWriter | Python xlsxwriter | Speedup |
+|---|---|---|---|---|
+| **Records** (list of dicts) | 500K | ~2.89s | ~27.32s | **9.4x** |
+| | 1M | ~5.74s | ~52.81s | **9.2x** |
+| **Pandas DataFrame** | 500K | ~1.19s | ~9.10s | **7.7x** |
+| | 1M | ~2.36s | ~19.25s | **8.2x** |
+| **Polars DataFrame** | 500K | ~1.33s | ~10.30s | **7.7x** |
+| | 1M | ~2.34s | ~17.12s | **7.3x** |
+
+<details>
+<summary>Key optimizations</summary>
+
+1. **Arrow zero-copy** for DataFrames — reads memory buffers directly via Arrow C Data Interface
+2. **First-row type caching** for Records — detect column types once, skip type cascade
+3. LTO (Link-Time Optimization) and single codegen unit
+4. Constant memory mode for large files
+5. Pre-allocated Format objects (created once, reused across all cells)
+6. Dict `values()` iteration instead of per-key hash lookups
+7. Lazy processing of Python iterables (including generators)
+8. High-precision floating point with ryu
+9. Efficient zlib compression
+
+</details>
+
+## Features
+
+**Data Sources**
+- List of dicts, generators/iterators, Pandas DataFrame, Polars DataFrame
+- All Python types: `str`, `int`, `float`, `bool`, `None`, `datetime`, `date`
+- Numpy scalar types (`numpy.int64`, `numpy.float64`, `numpy.bool_`)
+
+**Formatting & Styling**
+- Float number format (e.g. `"0.00"`)
+- Custom datetime format (e.g. `"dd/mm/yyyy"`)
+- Bold headers and bold index columns
+- Freeze panes (rows, columns, per-sheet overrides)
+
+**Output Options**
+- File path or `io.BytesIO` in-memory buffer
+- Password protection
+- Optional column auto-fit (`autofit=True/False`)
+- Multiple sheets in a single file
+
+**API**
+- Fluent builder via `FastExcel` class
+- Context manager (`with` statement) for auto-save
+- Lower-level functional API (`write_worksheet`, `write_worksheets`)
+
 ## Quick Start
 
 ```python
 from rustpy_xlsxwriter import FastExcel
 
-# One-liner
-FastExcel("output.xlsx").sheet("Sheet1", records).save()
+# Simple
+FastExcel("output.xlsx").sheet("Users", [{"Name": "Alice", "Age": 30}]).save()
 
-# Multiple sheets with options
-(
-    FastExcel("report.xlsx", password="secret")
-    .format(float_format="0.00", index_columns=["Name"])
-    .freeze(row=1, col=1)
-    .sheet("Users", user_records)
-    .sheet("Orders", order_records)
-    .save()
-)
-
-# Context manager (auto-saves on exit)
-with FastExcel("output.xlsx") as f:
-    f.sheet("Users", user_records)
-    f.sheet("Orders", order_records)
+# Full-featured with context manager
+with FastExcel("report.xlsx", password="secret") as f:
+    f.format(
+        float_format="0.00",
+        datetime_format="dd/mm/yyyy",
+        bold_headers=True,
+        index_columns=["ID"],
+    )
+    f.freeze(row=1)
+    f.sheet("Employees", employee_records)
+    f.sheet("Departments", dept_records)
 ```
-
-## Features
-
-- **~7.3x–9.4x faster** than Python's xlsxwriter
-- Fluent builder API via `FastExcel` class
-- Context manager support (`with` statement) for auto-save
-- Support for `str`, `int`, `float`, `bool`, `None`, `datetime` values
-- Numpy scalar types (`numpy.int64`, `numpy.float64`, `numpy.bool_`) handled correctly
-- Multiple sheets in a single file
-- Password protection
-- Freeze panes (rows & columns)
-- Float formatting, custom datetime formatting & bold index columns
-- Bold headers option
-- Pandas and **Polars** DataFrame support with **Arrow zero-copy** optimization
-- `io.BytesIO` in-memory buffer support
-- Generator/iterator streaming for memory-efficient large datasets
-- Optional `autofit` control for column widths
 
 ## Usage Examples
 
-### Single Sheet
+### Pandas & Polars DataFrames
 
 ```python
-from rustpy_xlsxwriter import FastExcel
-from datetime import datetime
-
-records = [
-    {"Name": "Alice", "Age": 30, "City": "New York", "Active": True, "Join Date": datetime(2023, 1, 15)},
-    {"Name": "Bob", "Age": 25, "City": "San Francisco", "Active": False, "Join Date": datetime(2023, 2, 1)},
-]
-
-FastExcel("output.xlsx").sheet("Employees", records).save()
-```
-
-### Multiple Sheets
-
-```python
+import pandas as pd
+import polars as pl
 from rustpy_xlsxwriter import FastExcel
 
-employees = [{"Name": "Alice", "Age": 30}, {"Name": "Bob", "Age": 25}]
-inventory = [{"Product": "Laptop", "Price": 1000.0}, {"Product": "Phone", "Price": 500.0}]
+# Pandas — Arrow zero-copy, dtype-aware
+df_pd = pd.DataFrame({"Name": ["Alice", "Bob"], "Score": [88.5, 92.3]})
+FastExcel("pandas.xlsx").sheet("Data", df_pd).save()
 
-(
-    FastExcel("report.xlsx")
-    .sheet("Employees", employees)
-    .sheet("Inventory", inventory)
-    .save()
-)
-```
-
-### Context Manager
-
-```python
-from rustpy_xlsxwriter import FastExcel
-
-# Auto-saves when exiting the block; skips save if an exception occurs
-with FastExcel("report.xlsx", password="secret") as f:
-    f.format(float_format="0.00")
-    f.freeze(row=1)
-    f.sheet("Users", user_records)
-    f.sheet("Orders", order_records)
+# Polars — native support, no .to_pandas() needed
+df_pl = pl.DataFrame({"Name": ["Alice", "Bob"], "Score": [88.5, 92.3]})
+FastExcel("polars.xlsx").sheet("Data", df_pl).save()
 ```
 
 ### Freeze Panes
 
 ```python
-from rustpy_xlsxwriter import FastExcel
+# Freeze header row on all sheets
+FastExcel("frozen.xlsx").freeze(row=1).sheet("Sheet1", data).save()
 
-# Freeze first row on all sheets
+# Per-sheet freeze configuration
 (
-    FastExcel("frozen.xlsx")
-    .freeze(row=1)
-    .sheet("Sheet1", records)
-    .sheet("Sheet2", more_records)
-    .save()
-)
-
-# Per-sheet freeze pane configuration
-(
-    FastExcel("custom_freeze.xlsx")
-    .freeze(row=1, col=0)                  # general (all sheets)
-    .freeze(row=1, col=2, sheet="Sheet1")  # override for Sheet1
-    .freeze(row=2, col=1, sheet="Sheet2")  # override for Sheet2
-    .sheet("Sheet1", data1)
-    .sheet("Sheet2", data2)
+    FastExcel("custom.xlsx")
+    .freeze(row=1)                             # all sheets
+    .freeze(row=1, col=2, sheet="Details")     # override for Details
+    .sheet("Summary", summary_data)
+    .sheet("Details", detail_data)
     .save()
 )
 ```
 
-### Pandas DataFrame
+### Generator Streaming
 
 ```python
-import pandas as pd
-from rustpy_xlsxwriter import FastExcel
-
-df = pd.DataFrame({"Name": ["Alice", "Bob"], "Age": [30, 25], "Score": [88.5, 92.3]})
-
-# Basic
-FastExcel("dataframe.xlsx").sheet("Data", df).save()
-
-# With styling
-(
-    FastExcel("styled.xlsx")
-    .format(float_format="0.00", index_columns=["Name"])
-    .sheet("Data", df)
-    .save()
-)
-```
-
-### Polars DataFrame
-
-```python
-import polars as pl
-from rustpy_xlsxwriter import FastExcel
-
-df = pl.DataFrame({"Name": ["Alice", "Bob"], "Age": [30, 25], "Score": [88.5, 92.3]})
-
-# Basic
-FastExcel("polars.xlsx").sheet("Data", df).save()
-
-# With styling
-(
-    FastExcel("styled.xlsx")
-    .format(float_format="0.00", bold_headers=True)
-    .sheet("Data", df)
-    .save()
-)
-```
-
-### Custom Datetime Format
-
-```python
-from rustpy_xlsxwriter import FastExcel
-
-# Default: "yyyy-mm-ddThh:mm:ss"
-# Custom format:
-FastExcel("report.xlsx").format(datetime_format="dd/mm/yyyy").sheet("Sheet1", records).save()
-```
-
-### Bold Headers
-
-```python
-from rustpy_xlsxwriter import FastExcel
-
-FastExcel("report.xlsx").format(bold_headers=True).sheet("Sheet1", records).save()
-```
-
-### In-Memory Buffer
-
-```python
-import io
-from rustpy_xlsxwriter import FastExcel
-
-buf = io.BytesIO()
-FastExcel(buf).sheet("Sheet1", [{"Name": "Alice", "Age": 30}]).save()
-
-xlsx_data = buf.getvalue()
-```
-
-### Generator Streaming (Memory-Efficient)
-
-```python
-from rustpy_xlsxwriter import FastExcel
-
 def rows():
     for i in range(1_000_000):
         yield {"id": i, "value": f"row_{i}"}
@@ -208,27 +138,24 @@ def rows():
 FastExcel("streamed.xlsx").sheet("Data", rows()).save()
 ```
 
-### Disable Autofit (Performance)
-
-For large datasets, disabling autofit can improve write performance:
+### In-Memory Buffer (Web Frameworks)
 
 ```python
+import io
 from rustpy_xlsxwriter import FastExcel
 
-FastExcel("large.xlsx", autofit=False).sheet("Data", large_records).save()
+buf = io.BytesIO()
+FastExcel(buf).sheet("Sheet1", records).save()
+xlsx_bytes = buf.getvalue()  # send as HTTP response
 ```
 
 ### Functional API
 
-The lower-level functional API is also available:
-
 ```python
 from rustpy_xlsxwriter import write_worksheet, write_worksheets
 
-# Single sheet
 write_worksheet(records, "output.xlsx", sheet_name="Sheet1", password="secret")
 
-# Multiple sheets
 write_worksheets(
     [{"Sheet1": records1}, {"Sheet2": records2}],
     "output.xlsx",
@@ -242,13 +169,13 @@ write_worksheets(
 
 | Method | Description |
 |---|---|
-| `FastExcel(target, *, password=None, autofit=True)` | Create writer for file path or `BytesIO` buffer. Set `autofit=False` to skip column width auto-adjustment. |
-| `.format(*, float_format=None, datetime_format=None, index_columns=None, bold_headers=None)` | Set number/datetime format, bold index columns, and bold headers |
+| `FastExcel(target, *, password=None, autofit=True)` | Create writer for file path or `BytesIO` buffer |
+| `.format(*, float_format, datetime_format, index_columns, bold_headers)` | Set number/datetime format and styling |
 | `.freeze(*, row=None, col=None, sheet=None)` | Configure freeze panes (general or per-sheet) |
 | `.sheet(name, data)` | Add a worksheet (list of dicts, generator, or DataFrame) |
 | `.save()` | Write all sheets and save |
 
-`FastExcel` also supports the context manager protocol (`with` statement). When used as a context manager, `.save()` is called automatically on exit unless an exception occurred.
+Supports context manager (`with` statement) — auto-saves on exit, skips save on exception.
 
 ### Functional API
 
@@ -258,89 +185,74 @@ write_worksheets(
 | `write_worksheets(records_with_sheet_name, file_name, ...)` | Write multiple sheets |
 | `validate_sheet_name(name)` | Check if sheet name is valid for Excel |
 
-### Metadata
+### Supported Data Types
 
-| Function | Description |
+| Python Type | Excel Output |
 |---|---|
-| `get_version()` | Package version |
-| `get_name()` | Package name |
-| `get_authors()` | Package authors |
-| `get_description()` | Package description |
-| `get_repository()` | Repository URL |
-| `get_homepage()` | Homepage URL |
-| `get_license()` | License identifier |
+| `str` | Text |
+| `int` | Number |
+| `float` | Number (with optional format) |
+| `bool` | Boolean |
+| `None` | Empty cell |
+| `datetime.datetime` | DateTime (with optional format) |
+| `datetime.date` | Date (with optional format) |
+| `numpy.int64` / `numpy.float64` | Number |
+| `numpy.bool_` | Boolean |
+| `dict`, other | String representation |
 
-## Performance
+## Examples
 
-RustPy-XlsxWriter delivers exceptional speed improvements compared to traditional Python solutions, achieving up to **~9x faster** processing speeds while maintaining optimal memory usage.
+See [`examples/`](examples/) for 13 runnable scripts + a Jupyter notebook:
 
-Benchmarked via [`benchmark.py`](benchmark.py) (`python benchmark.py`):
-
-### Records (list of dicts)
-
-| Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
-| --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~2.89s             | ~27.32s           | **9.4x faster**  |
-| 1,000,000 | ~5.74s             | ~52.81s           | **9.2x faster**  |
-
-### Pandas DataFrame (Arrow zero-copy)
-
-| Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
-| --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~1.19s             | ~9.10s            | **7.7x faster**  |
-| 1,000,000 | ~2.36s             | ~19.25s           | **8.2x faster**  |
-
-### Polars DataFrame (Arrow zero-copy)
-
-| Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
-| --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~1.33s             | ~10.30s           | **7.7x faster**  |
-| 1,000,000 | ~2.34s             | ~17.12s           | **7.3x faster**  |
-
-### Key optimizations
-
-1. **Arrow zero-copy** for DataFrames — reads memory buffers directly, no Python object conversion
-2. Rust's zero-cost abstractions and memory management
-3. LTO (Link-Time Optimization) and single codegen unit for maximum inlining
-4. Constant memory mode for large files
-5. Lazy processing of Python iterables (including generators)
-6. Pre-allocated Format objects (created once, reused across all cells)
-7. Dict `values()` iteration instead of per-key hash lookups
-8. Correct numpy scalar type handling (no string fallback)
-9. High-precision floating point with ryu
-10. Efficient zlib compression
+| File | Description |
+|---|---|
+| [`01_basic.py`](examples/01_basic.py) | Single sheet from list of dicts |
+| [`02_multiple_sheets.py`](examples/02_multiple_sheets.py) | Multiple sheets in one file |
+| [`03_dataframe.py`](examples/03_dataframe.py) | Pandas DataFrame with styling |
+| [`04_freeze_panes.py`](examples/04_freeze_panes.py) | Freeze rows, columns, per-sheet config |
+| [`05_bytesio.py`](examples/05_bytesio.py) | In-memory buffer for web frameworks |
+| [`06_generator.py`](examples/06_generator.py) | Memory-efficient streaming (100K rows) |
+| [`07_password.py`](examples/07_password.py) | Password-protected workbook |
+| [`08_full_featured.py`](examples/08_full_featured.py) | All features combined |
+| [`09_polars.py`](examples/09_polars.py) | Polars DataFrame (native support) |
+| [`10_context_manager.py`](examples/10_context_manager.py) | Auto-save with `with` statement |
+| [`11_datetime_format.py`](examples/11_datetime_format.py) | Custom datetime/date formatting |
+| [`12_bold_headers.py`](examples/12_bold_headers.py) | Bold header row |
+| [`13_autofit.py`](examples/13_autofit.py) | Column auto-fit toggle |
+| [`quickstart.ipynb`](examples/quickstart.ipynb) | Jupyter notebook walkthrough |
 
 ## Testing
 
-The test suite uses `pytest` with content verification via `openpyxl`:
-
 ```bash
-# Run unit tests only (fast, ~1 second)
+# Unit tests (~1 second)
 pytest tests/ -m "not benchmark"
 
-# Run all tests including benchmarks (~2 minutes)
+# All tests including benchmarks
 pytest tests/
 
-# Run a specific test file
-pytest tests/test_dataframe.py -v
+# Benchmark only
+python benchmark.py
 ```
 
-Test structure:
+<details>
+<summary>Test structure (86 tests)</summary>
 
-| File | Tests |
+| File | Coverage |
 |---|---|
 | `test_metadata.py` | Package metadata functions |
 | `test_validation.py` | Sheet name validation (unicode, length, special chars) |
-| `test_write_single.py` | Single sheet: types, generator, context manager, autofit |
+| `test_write_single.py` | Single sheet: all types, generator, context manager, autofit |
 | `test_write_multi.py` | Multiple sheets |
-| `test_write_functional.py` | `write_worksheet()`, `write_worksheets()` |
+| `test_write_functional.py` | Functional API |
 | `test_freeze_panes.py` | Freeze panes (single & multi-sheet) |
 | `test_password.py` | Password protection |
 | `test_bytesio.py` | In-memory buffer I/O |
 | `test_dataframe.py` | Pandas DataFrame, numpy scalar types |
 | `test_polars.py` | Polars DataFrame: types, datetime, date, null, styling |
-| `test_styling.py` | Float format, datetime format, bold headers, bold index columns |
-| `test_benchmark.py` | 1M row benchmarks (rustpy vs xlsxwriter) |
+| `test_styling.py` | Float format, datetime format, bold headers, index columns |
+| `test_benchmark.py` | Performance benchmarks (Records + Pandas + Polars vs xlsxwriter) |
+
+</details>
 
 ## Contributing
 
@@ -348,12 +260,8 @@ Contributions are welcome! Please submit issues or pull requests on the [GitHub 
 
 ## License
 
-This project is licensed under the MIT ![License](LICENSE).
+This project is licensed under the MIT [License](LICENSE).
 
 ## Acknowledgements
 
-This project is inspired by [Rust-XlsxWriter](https://github.com/jmcnamara/rust_xlsxwriter) and [PyO3](https://github.com/pyo3/pyo3) with the help of [maturin](https://github.com/PyO3/maturin).
-
-## Contributors
-
-- [Rahmad Afandi](https://github.com/rahmadafandi)
+This project is powered by [rust_xlsxwriter](https://github.com/jmcnamara/rust_xlsxwriter), [PyO3](https://github.com/pyo3/pyo3), and [maturin](https://github.com/PyO3/maturin).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ with FastExcel("output.xlsx") as f:
 
 ## Features
 
-- **~7.7x–9.1x faster** than Python's xlsxwriter
+- **~7.3x–9.0x faster** than Python's xlsxwriter
 - Fluent builder API via `FastExcel` class
 - Context manager support (`with` statement) for auto-save
 - Support for `str`, `int`, `float`, `bool`, `None`, `datetime` values
@@ -280,22 +280,22 @@ Benchmarked via [`benchmark.py`](benchmark.py) (`python benchmark.py`):
 
 | Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
 | --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~2.98s             | ~27.20s           | **9.1x faster**  |
-| 1,000,000 | ~5.95s             | ~53.15s           | **8.9x faster**  |
+| 500,000   | ~2.95s             | ~26.67s           | **9.0x faster**  |
+| 1,000,000 | ~5.86s             | ~52.36s           | **8.9x faster**  |
 
 ### Pandas DataFrame (Arrow zero-copy)
 
 | Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
 | --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~1.21s             | ~9.30s            | **7.7x faster**  |
-| 1,000,000 | ~2.39s             | ~18.44s           | **7.7x faster**  |
+| 500,000   | ~1.18s             | ~9.01s            | **7.6x faster**  |
+| 1,000,000 | ~2.36s             | ~18.00s           | **7.6x faster**  |
 
 ### Polars DataFrame (Arrow zero-copy)
 
 | Records   | RustPy-XlsxWriter | Python xlsxwriter | Speedup          |
 | --------- | ------------------ | ----------------- | ---------------- |
-| 500,000   | ~1.19s             | ~8.64s            | **7.2x faster**  |
-| 1,000,000 | ~2.38s             | ~18.72s           | **7.9x faster**  |
+| 500,000   | ~1.18s             | ~8.63s            | **7.3x faster**  |
+| 1,000,000 | ~2.35s             | ~17.21s           | **7.3x faster**  |
 
 ### Key optimizations
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.3.x   | Yes                |
+| < 0.3   | No                 |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do NOT** open a public GitHub issue
+2. Email **rahmadafandiii@gmail.com** with details
+3. Include steps to reproduce if possible
+
+We will acknowledge receipt within 48 hours and provide a timeline for a fix.

--- a/examples/08_full_featured.py
+++ b/examples/08_full_featured.py
@@ -34,19 +34,26 @@ departments = [
     {"Dept": "Sales", "Budget": 350000.00, "Headcount": 18},
 ]
 
-(
-    FastExcel("output_full.xlsx", password="admin123")
-    .format(float_format="0.00", index_columns=["ID", "Dept"])
-    .freeze(row=1)
-    .freeze(row=1, col=2, sheet="Employees")  # extra freeze for Employees
-    .sheet("Employees", employees)
-    .sheet("Departments", departments)
-    .save()
-)
+# Using context manager for auto-save
+with FastExcel("output_full.xlsx", password="admin123") as f:
+    f.format(
+        float_format="0.00",
+        datetime_format="dd/mm/yyyy",
+        index_columns=["ID", "Dept"],
+        bold_headers=True,
+    )
+    f.freeze(row=1)
+    f.freeze(row=1, col=2, sheet="Employees")
+    f.sheet("Employees", employees)
+    f.sheet("Departments", departments)
+
 print("✅ output_full.xlsx created")
 print("   - 2 sheets: Employees, Departments")
 print("   - Password protected")
 print("   - Float format: 0.00")
+print("   - Datetime format: dd/mm/yyyy")
+print("   - Bold headers")
 print("   - Bold index columns: ID, Dept")
 print("   - Frozen header row on all sheets")
 print("   - Extra column freeze on Employees sheet")
+print("   - Auto-saved via context manager")

--- a/examples/09_polars.py
+++ b/examples/09_polars.py
@@ -1,0 +1,26 @@
+"""Write a Polars DataFrame to Excel (native support, no .to_pandas() needed)."""
+
+import polars as pl
+
+from rustpy_xlsxwriter import FastExcel
+
+df = pl.DataFrame(
+    {
+        "Name": ["Alice", "Bob", "Charlie"],
+        "Score": [95.678, 88.123, 72.456],
+        "Passed": [True, True, False],
+    }
+)
+
+# Basic
+FastExcel("output_polars.xlsx").sheet("Results", df).save()
+print("✅ output_polars.xlsx created")
+
+# With styling
+(
+    FastExcel("output_polars_styled.xlsx")
+    .format(float_format="0.00", bold_headers=True, index_columns=["Name"])
+    .sheet("Results", df)
+    .save()
+)
+print("✅ output_polars_styled.xlsx created (float_format + bold headers + bold index)")

--- a/examples/10_context_manager.py
+++ b/examples/10_context_manager.py
@@ -1,0 +1,33 @@
+"""Use FastExcel as a context manager for auto-save.
+
+The file is automatically saved when exiting the `with` block.
+If an exception occurs, the file is NOT saved.
+"""
+
+from rustpy_xlsxwriter import FastExcel
+
+records = [
+    {"Name": "Alice", "Age": 30},
+    {"Name": "Bob", "Age": 25},
+]
+
+# Auto-saves on exit
+with FastExcel("output_context.xlsx") as f:
+    f.format(bold_headers=True)
+    f.freeze(row=1)
+    f.sheet("Users", records)
+
+print("✅ output_context.xlsx created (auto-saved via context manager)")
+
+# Exception safety: file is NOT saved if an error occurs
+try:
+    with FastExcel("output_should_not_exist.xlsx") as f:
+        f.sheet("Data", records)
+        raise ValueError("Something went wrong!")
+except ValueError:
+    pass
+
+import os
+
+assert not os.path.exists("output_should_not_exist.xlsx")
+print("✅ Confirmed: file not created when exception occurred")

--- a/examples/11_datetime_format.py
+++ b/examples/11_datetime_format.py
@@ -1,0 +1,38 @@
+"""Customize datetime format in Excel output."""
+
+from datetime import date, datetime
+
+from rustpy_xlsxwriter import FastExcel
+
+records = [
+    {"Event": "Launch", "When": datetime(2024, 6, 15, 10, 30, 0)},
+    {"Event": "Review", "When": datetime(2024, 7, 1, 14, 0, 0)},
+    {"Event": "Release", "When": datetime(2024, 8, 20, 9, 15, 0)},
+]
+
+# Default format: yyyy-mm-ddThh:mm:ss
+FastExcel("output_datetime_default.xlsx").sheet("Events", records).save()
+print("✅ output_datetime_default.xlsx (default: yyyy-mm-ddThh:mm:ss)")
+
+# Custom format: dd/mm/yyyy
+(
+    FastExcel("output_datetime_custom.xlsx")
+    .format(datetime_format="dd/mm/yyyy hh:mm")
+    .sheet("Events", records)
+    .save()
+)
+print("✅ output_datetime_custom.xlsx (custom: dd/mm/yyyy hh:mm)")
+
+# Date objects (not datetime)
+date_records = [
+    {"Name": "Alice", "Birthday": date(1994, 3, 20)},
+    {"Name": "Bob", "Birthday": date(1999, 7, 10)},
+]
+
+(
+    FastExcel("output_dates.xlsx")
+    .format(datetime_format="dd-mmm-yyyy")
+    .sheet("Birthdays", date_records)
+    .save()
+)
+print("✅ output_dates.xlsx (date objects with dd-mmm-yyyy format)")

--- a/examples/12_bold_headers.py
+++ b/examples/12_bold_headers.py
@@ -1,0 +1,17 @@
+"""Make header row bold."""
+
+from rustpy_xlsxwriter import FastExcel
+
+records = [
+    {"Name": "Alice", "Score": 95.5, "Grade": "A"},
+    {"Name": "Bob", "Score": 88.0, "Grade": "B+"},
+    {"Name": "Charlie", "Score": 72.3, "Grade": "B-"},
+]
+
+(
+    FastExcel("output_bold_headers.xlsx")
+    .format(bold_headers=True)
+    .sheet("Results", records)
+    .save()
+)
+print("✅ output_bold_headers.xlsx created (bold header row)")

--- a/examples/13_autofit.py
+++ b/examples/13_autofit.py
@@ -1,0 +1,23 @@
+"""Control column auto-fit behavior.
+
+By default, columns are auto-fitted to content width.
+Disable autofit for large datasets to improve write performance.
+"""
+
+from rustpy_xlsxwriter import FastExcel
+
+
+def generate_rows(n: int):
+    for i in range(n):
+        yield {"id": i, "value": f"row_{i}", "score": i * 0.1}
+
+
+# Default: autofit enabled (columns adjust to content width)
+FastExcel("output_autofit_on.xlsx").sheet("Data", generate_rows(100)).save()
+print("✅ output_autofit_on.xlsx (autofit enabled — columns fit content)")
+
+# Disabled: faster for large datasets
+FastExcel("output_autofit_off.xlsx", autofit=False).sheet(
+    "Data", generate_rows(100_000)
+).save()
+print("✅ output_autofit_off.xlsx (autofit disabled — faster for large data)")

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -254,7 +254,7 @@ def validate_sheet_name(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def get_version() -> str:
-    """Return the package version string (e.g. ``'0.2.0'``)."""
+    """Return the package version string (e.g. ``'0.3.0'``)."""
     ...
 
 def get_name() -> str:

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -254,7 +254,7 @@ def validate_sheet_name(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def get_version() -> str:
-    """Return the package version string (e.g. ``'0.3.0'``)."""
+    """Return the package version string (e.g. ``'0.3.1'``)."""
     ...
 
 def get_name() -> str:

--- a/src/arrow_ffi.rs
+++ b/src/arrow_ffi.rs
@@ -1,0 +1,45 @@
+//! Arrow C Stream Interface bridge — converts Python objects with
+//! `__arrow_c_stream__` into Rust `arrow_array::RecordBatchReader`
+//! without the `pyo3-arrow` crate (avoids chrono-tz compile issues).
+
+use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
+use arrow_array::RecordBatchReader;
+use arrow_schema::ArrowError;
+use pyo3::prelude::*;
+use pyo3::Py;
+
+/// Call `obj.__arrow_c_stream__()` and consume the returned PyCapsule
+/// to produce a `Box<dyn RecordBatchReader + Send>`.
+pub fn stream_to_reader(
+    obj: &Py<PyAny>,
+    py: Python<'_>,
+) -> PyResult<Box<dyn RecordBatchReader + Send>> {
+    // 1. Call __arrow_c_stream__(None) → PyCapsule
+    let capsule = obj.call_method1(py, "__arrow_c_stream__", (py.None(),))?;
+    let capsule_bound = capsule.bind(py);
+
+    // 2. Extract the raw pointer from the PyCapsule
+    let ptr = unsafe {
+        let cap_ptr = pyo3::ffi::PyCapsule_GetPointer(
+            capsule_bound.as_ptr(),
+            b"arrow_array_stream\0".as_ptr() as *const _,
+        );
+        if cap_ptr.is_null() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "Failed to get pointer from Arrow PyCapsule",
+            ));
+        }
+        cap_ptr as *mut FFI_ArrowArrayStream
+    };
+
+    // 3. Convert FFI stream to Rust RecordBatchReader
+    let stream =
+        unsafe { ArrowArrayStreamReader::from_raw(ptr) }.map_err(|e: ArrowError| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Failed to create Arrow reader from stream: {}",
+                e
+            ))
+        })?;
+
+    Ok(Box::new(stream))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod arrow_ffi;
 mod arrow_writer;
 mod data_types;
 mod metadata;

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -60,16 +60,9 @@ fn write_worksheet_content(
 
     match records {
         WorksheetData::ArrowStream(stream_obj) => {
-            // Zero-copy Arrow path: read RecordBatches directly from memory
+            // Zero-copy Arrow path via Arrow C Stream Interface (no pyo3-arrow dependency)
             let arrow_ok = (|| -> PyResult<()> {
-                let stream = pyo3_arrow::PyRecordBatchReader::extract(
-                    stream_obj.bind(py).as_borrowed(),
-                )?;
-                let reader = stream.into_reader().map_err(|e| {
-                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Failed to create Arrow reader: {}", e
-                    ))
-                })?;
+                let reader = crate::arrow_ffi::stream_to_reader(stream_obj, py)?;
 
                 // Write headers from schema (handles empty DataFrames with 0 batches)
                 let schema = reader.schema();

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -132,6 +132,9 @@ fn write_worksheet_content(
             if let Ok(rows) = records_list.bind(py).try_iter() {
                 let mut headers: Vec<String> = Vec::new();
                 let mut headers_written = false;
+                // Column type cache: detected from first row, used for fast dispatch
+                // 0=unknown, 1=string, 2=float, 3=bool, 4=int, 5=datetime, 6=date
+                let mut col_types: Vec<u8> = Vec::new();
 
                 for (row_idx, row_res) in rows.enumerate() {
                     let row_obj = row_res?;
@@ -164,21 +167,91 @@ fn write_worksheet_content(
                                 }
                             }
                         }
+                        col_types.resize(headers.len(), 0);
                         headers_written = true;
                     }
 
                     // Iterate values() directly — avoids per-cell hash lookup
                     let row_u32 = (row_idx + 1) as u32;
                     for (col, value) in row_dict.values().iter().enumerate() {
-                        write_py_any_bound(
-                            worksheet,
-                            row_u32,
-                            col as u16,
-                            &value,
-                            float_fmt.as_ref(),
-                            Some(&datetime_fmt),
-                            &mut datetime_cols_set,
-                        )?;
+                        let col_u16 = col as u16;
+
+                        if value.is_none() {
+                            worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
+                            continue;
+                        }
+
+                        // Try cached type first (fast path)
+                        let cached = if col < col_types.len() { col_types[col] } else { 0 };
+                        let written = match cached {
+                            1 => {
+                                if let Ok(s) = value.cast::<pyo3::types::PyString>() {
+                                    worksheet.write_string(row_u32, col_u16, s.to_str()?).map_err(xlsx_err)?;
+                                    true
+                                } else { false }
+                            }
+                            2 => {
+                                if let Ok(f) = value.cast::<pyo3::types::PyFloat>() {
+                                    let val = f.value();
+                                    if let Some(fmt) = float_fmt.as_ref() {
+                                        worksheet.write_number_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
+                                    } else {
+                                        worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
+                                    }
+                                    true
+                                } else { false }
+                            }
+                            3 => {
+                                if let Ok(b) = value.cast::<pyo3::types::PyBool>() {
+                                    worksheet.write_boolean(row_u32, col_u16, b.is_true()).map_err(xlsx_err)?;
+                                    true
+                                } else { false }
+                            }
+                            4 => {
+                                if let Ok(i) = value.cast::<pyo3::types::PyInt>() {
+                                    let val: f64 = i.extract()?;
+                                    worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
+                                    true
+                                } else { false }
+                            }
+                            5 => {
+                                if let Ok(dt) = value.cast::<PyDateTime>() {
+                                    if datetime_cols_set.insert(col_u16) {
+                                        worksheet.set_column_format(col_u16, &datetime_fmt).map_err(xlsx_err)?;
+                                    }
+                                    let excel_dt = ExcelDateTime::from_ymd(dt.get_year() as u16, dt.get_month() as u8, dt.get_day() as u8)
+                                        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Failed to create datetime: {}", e)))?
+                                        .and_hms(dt.get_hour() as u16, dt.get_minute() as u8, dt.get_second() as u8)
+                                        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Failed to create timestamp: {}", e)))?;
+                                    worksheet.write_datetime(row_u32, col_u16, &excel_dt).map_err(xlsx_err)?;
+                                    true
+                                } else { false }
+                            }
+                            6 => {
+                                if let Ok(d) = value.cast::<PyDate>() {
+                                    if datetime_cols_set.insert(col_u16) {
+                                        worksheet.set_column_format(col_u16, &datetime_fmt).map_err(xlsx_err)?;
+                                    }
+                                    let excel_dt = ExcelDateTime::from_ymd(d.get_year() as u16, d.get_month() as u8, d.get_day() as u8)
+                                        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Failed to create date: {}", e)))?;
+                                    worksheet.write_datetime(row_u32, col_u16, &excel_dt).map_err(xlsx_err)?;
+                                    true
+                                } else { false }
+                            }
+                            _ => false,
+                        };
+
+                        if !written {
+                            // Full type dispatch (first row or cache miss)
+                            let detected = write_py_any_bound_detect(
+                                worksheet, row_u32, col_u16, &value,
+                                float_fmt.as_ref(), Some(&datetime_fmt), &mut datetime_cols_set,
+                            )?;
+                            // Cache detected type for this column
+                            if col < col_types.len() && col_types[col] == 0 {
+                                col_types[col] = detected;
+                            }
+                        }
                     }
                 }
             }
@@ -580,6 +653,92 @@ fn write_py_any_bound(
     // Final fallback to string representation
     worksheet.write_string(row, col, value.to_string()).map_err(xlsx_err)?;
     Ok(())
+}
+
+/// Same as write_py_any_bound but returns detected type ID for caching.
+/// 0=unknown, 1=string, 2=float, 3=bool, 4=int, 5=datetime, 6=date
+fn write_py_any_bound_detect(
+    worksheet: &mut rust_xlsxwriter::Worksheet,
+    row: u32,
+    col: u16,
+    value: &Bound<PyAny>,
+    float_fmt: Option<&Format>,
+    datetime_fmt: Option<&Format>,
+    datetime_cols_set: &mut HashSet<u16>,
+) -> PyResult<u8> {
+    if value.is_none() {
+        worksheet.write_string(row, col, "").map_err(xlsx_err)?;
+        return Ok(0);
+    }
+
+    if let Ok(s) = value.cast::<pyo3::types::PyString>() {
+        worksheet.write_string(row, col, s.to_str()?).map_err(xlsx_err)?;
+        return Ok(1);
+    }
+
+    if let Ok(f) = value.cast::<pyo3::types::PyFloat>() {
+        let val = f.value();
+        if let Some(fmt) = float_fmt {
+            worksheet.write_number_with_format(row, col, val, fmt).map_err(xlsx_err)?;
+        } else {
+            worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+        }
+        return Ok(2);
+    }
+
+    if let Ok(b) = value.cast::<pyo3::types::PyBool>() {
+        worksheet.write_boolean(row, col, b.is_true()).map_err(xlsx_err)?;
+        return Ok(3);
+    }
+
+    if let Ok(i) = value.cast::<pyo3::types::PyInt>() {
+        let val: f64 = i.extract()?;
+        worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+        return Ok(4);
+    }
+
+    if let Ok(dt) = value.cast::<PyDateTime>() {
+        if let Some(fmt) = datetime_fmt {
+            if datetime_cols_set.insert(col) {
+                worksheet.set_column_format(col, fmt).map_err(xlsx_err)?;
+            }
+        }
+        let excel_dt = ExcelDateTime::from_ymd(dt.get_year() as u16, dt.get_month() as u8, dt.get_day() as u8)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Failed to create datetime: {}", e)))?
+            .and_hms(dt.get_hour() as u16, dt.get_minute() as u8, dt.get_second() as u8)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Failed to create timestamp: {}", e)))?;
+        worksheet.write_datetime(row, col, &excel_dt).map_err(xlsx_err)?;
+        return Ok(5);
+    }
+
+    if let Ok(d) = value.cast::<PyDate>() {
+        if let Some(fmt) = datetime_fmt {
+            if datetime_cols_set.insert(col) {
+                worksheet.set_column_format(col, fmt).map_err(xlsx_err)?;
+            }
+        }
+        let excel_dt = ExcelDateTime::from_ymd(d.get_year() as u16, d.get_month() as u8, d.get_day() as u8)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Failed to create date: {}", e)))?;
+        worksheet.write_datetime(row, col, &excel_dt).map_err(xlsx_err)?;
+        return Ok(6);
+    }
+
+    if let Ok(val) = value.extract::<bool>() {
+        worksheet.write_boolean(row, col, val).map_err(xlsx_err)?;
+        return Ok(3);
+    }
+
+    if let Ok(val) = value.extract::<f64>() {
+        if let Some(fmt) = float_fmt {
+            worksheet.write_number_with_format(row, col, val, fmt).map_err(xlsx_err)?;
+        } else {
+            worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+        }
+        return Ok(2);
+    }
+
+    worksheet.write_string(row, col, value.to_string()).map_err(xlsx_err)?;
+    Ok(1)
 }
 
 


### PR DESCRIPTION
- Detect column types from first row, cache per column
- Subsequent rows try cached type directly (single cast) instead of full cascade (5-7 failed casts per cell)
- Falls back to full type dispatch on cache miss (mixed types)
- Update README with latest benchmark results