### PR TITLE
feat: cell Format API, per-column widths, PathLike + CSV improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ docs/_build/
 
 # COD SPEED
 .codspeed
+
+# Brainstorming / design specs (local only)
+docs/superpowers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "rustpy-xlsxwriter"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpy-xlsxwriter"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 authors = ["Rahmad Afandi <rahmadafandiii@gmail.com>"]
 description = "High-performance Excel and CSV file generation powered by Rust (~7-9x faster)"

--- a/README.md
+++ b/README.md
@@ -138,6 +138,55 @@ FastExcel("frozen.xlsx").freeze(row=1).sheet("Sheet1", data).save()
 )
 ```
 
+### Column widths
+
+Override `autofit` with explicit widths (Excel character units):
+
+```python
+from rustpy_xlsxwriter import FastExcel
+
+(
+    FastExcel("out.xlsx")
+    .sheet("RawData", rows, column_width=15)                    # uniform
+    .sheet("Meta", meta, column_widths={"row": 7, "var": 22})   # per-column (by name)
+    .sheet("Other", rows, column_widths=[7, 22, 40])            # per-column (positional)
+    .save()
+)
+```
+
+`column_widths` overrides `column_width` per named/positional column, and explicit
+widths win over `autofit=True`. Unknown column names and out-of-range list indices
+emit a warning and are skipped. For `write_worksheets`, pass `column_width` /
+`column_widths` as dicts keyed by sheet name (with a `"general"` fallback key).
+
+### Cell formatting
+
+Build a reusable `Format` and attach it per column or to the header row:
+
+```python
+from rustpy_xlsxwriter import FastExcel, Format
+
+money = Format().set_num_format("$#,##0.00").set_font_color("#006600")
+header = Format().set_bold().set_background_color("#1F4E78").set_font_color("white")
+
+(
+    FastExcel("out.xlsx")
+    .sheet("Products", rows, header_format=header, column_formats={"price": money})
+    .save()
+)
+```
+
+`Format` chains setters (font, fill, border, alignment, number format). Colors
+accept `"#RRGGBB"` or names (`"red"`); enum-valued setters take lowercase strings
+(`set_align("center")`, `set_border("thin")`). A column's format wins over
+`float_format` / `datetime_format`. For `write_worksheets`, pass `column_formats` /
+`header_format` as dicts keyed by sheet name (with a `"general"` fallback key).
+
+> **Note:** a column format wins *entirely* over the automatic number format. On
+> a date/datetime column, a `Format` without `set_num_format(...)` makes cells
+> show the raw Excel serial number — chain `.set_num_format("yyyy-mm-dd")` (or
+> similar) to keep a date display.
+
 ### Generator Streaming
 
 ```python
@@ -181,7 +230,7 @@ from rustpy_xlsxwriter import write_worksheet, write_worksheets
 write_worksheet(records, "output.xlsx", sheet_name="Sheet1", password="secret")
 
 write_worksheets(
-    [{"Sheet1": records1}, {"Sheet2": records2}],
+    [("Sheet1", records1), ("Sheet2", records2)],
     "output.xlsx",
     freeze_panes={"general": {"row": 1, "col": 0}},
 )
@@ -227,7 +276,7 @@ Supports context manager (`with` statement) — auto-saves on exit, skips save o
 
 ## Examples
 
-See [`examples/`](examples/) for 13 runnable scripts + a Jupyter notebook:
+See [`examples/`](examples/) for 16 runnable scripts + a Jupyter notebook:
 
 | File | Description |
 |---|---|
@@ -245,6 +294,8 @@ See [`examples/`](examples/) for 13 runnable scripts + a Jupyter notebook:
 | [`12_bold_headers.py`](examples/12_bold_headers.py) | Bold header row |
 | [`13_autofit.py`](examples/13_autofit.py) | Column auto-fit toggle |
 | [`14_csv_tsv.py`](examples/14_csv_tsv.py) | CSV/TSV output (~5x faster) |
+| [`15_column_widths.py`](examples/15_column_widths.py) | Uniform & per-column widths |
+| [`16_cell_formats.py`](examples/16_cell_formats.py) | Cell formatting (Format class) |
 | [`quickstart.ipynb`](examples/quickstart.ipynb) | Jupyter notebook walkthrough |
 
 ## Testing

--- a/benchmark.py
+++ b/benchmark.py
@@ -154,7 +154,7 @@ def main() -> None:
         p2 = os.path.join(TMP_DIR, f"records_{n}_xlsxwriter.xlsx")
 
         print(f"  rustpy-xlsxwriter...", end=" ", flush=True)
-        t_r = bench("", lambda: FastExcel(p1, password="pw").sheet("B", records).save())
+        t_r = bench("", lambda: FastExcel(p1, autofit=False).sheet("B", records).save())
         print(f"{t_r:.2f}s")
 
         print(f"  xlsxwriter...", end=" ", flush=True)

--- a/examples/15_column_widths.py
+++ b/examples/15_column_widths.py
@@ -1,0 +1,32 @@
+"""Per-column and uniform column widths (issue #17)."""
+
+from rustpy_xlsxwriter import FastExcel, write_worksheets
+
+meta = [
+    {"row": 1, "var": "age", "label": "Age in years", "type": "int", "format": "0"},
+    {"row": 2, "var": "name", "label": "Full legal name", "type": "str", "format": "@"},
+]
+raw = [{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}]
+
+# Builder: uniform on one sheet, per-column (by name) on another.
+(
+    FastExcel("output_15_column_widths.xlsx", autofit=False)
+    .sheet("RawData", raw, column_width=15)
+    .sheet(
+        "Meta",
+        meta,
+        column_widths={"row": 7, "var": 22, "label": 91, "type": 14, "format": 12},
+    )
+    .save()
+)
+
+# Functional multi-sheet form, keyed by sheet name with a "general" fallback.
+write_worksheets(
+    [("RawData", raw), ("Meta", meta)],
+    "output_15_column_widths_functional.xlsx",
+    autofit=False,
+    column_width={"general": 15},
+    column_widths={"Meta": [7, 22, 91, 14, 12]},
+)
+
+print("Wrote output_15_column_widths*.xlsx")

--- a/examples/16_cell_formats.py
+++ b/examples/16_cell_formats.py
@@ -1,0 +1,25 @@
+"""Cell-level formatting via the Format class (issue #18)."""
+
+from rustpy_xlsxwriter import FastExcel, Format
+
+records = [
+    {"product": "Widget", "price": 19.99, "qty": 100},
+    {"product": "Gadget", "price": 49.50, "qty": 25},
+]
+
+money = Format().set_num_format("$#,##0.00").set_font_color("#006600")
+header = Format().set_bold().set_background_color("#1F4E78").set_font_color("white")
+qty = Format().set_align("center").set_border("thin")
+
+(
+    FastExcel("output_16_cell_formats.xlsx", autofit=True)
+    .sheet(
+        "Products",
+        records,
+        header_format=header,
+        column_formats={"price": money, "qty": qty},
+    )
+    .save()
+)
+
+print("Wrote output_16_cell_formats.xlsx")

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -63,15 +63,39 @@ from typing import (
     Union,
 )
 
+import os as _os
 from importlib.metadata import metadata as _metadata
 from importlib.metadata import version as _version
 
 from .rustpy_xlsxwriter import (
+    Format,
     validate_sheet_name,
-    write_csv,
-    write_worksheet,
-    write_worksheets,
 )
+from .rustpy_xlsxwriter import write_csv as _write_csv_rs
+from .rustpy_xlsxwriter import write_worksheet as _write_worksheet_rs
+from .rustpy_xlsxwriter import write_worksheets as _write_worksheets_rs
+
+
+def _coerce_target(target: Any) -> Any:
+    """Accept str, bytes, or any os.PathLike as a file path; pass other
+    objects (file-like buffers) through unchanged."""
+    if isinstance(target, _os.PathLike):
+        return _os.fspath(target)
+    return target
+
+
+def write_worksheet(records, file_name, *args, **kwargs):
+    return _write_worksheet_rs(records, _coerce_target(file_name), *args, **kwargs)
+
+
+def write_worksheets(records_with_sheet_name, file_name, *args, **kwargs):
+    return _write_worksheets_rs(
+        records_with_sheet_name, _coerce_target(file_name), *args, **kwargs
+    )
+
+
+def write_csv(records, file_name, *args, **kwargs):
+    return _write_csv_rs(records, _coerce_target(file_name), *args, **kwargs)
 
 _PKG = "rustpy-xlsxwriter"
 _META = _metadata(_PKG)
@@ -149,7 +173,7 @@ class FastExcel:
 
     def __init__(
         self,
-        target: Union[str, BinaryIO],
+        target: Union[str, _os.PathLike, BinaryIO],
         *,
         password: Optional[str] = None,
         autofit: bool = True,
@@ -157,7 +181,8 @@ class FastExcel:
         """Create a new writer.
 
         Args:
-            target: File path (``str``) or writable binary buffer
+            target: File path (``str`` or :class:`os.PathLike`, e.g.
+                ``pathlib.Path``) or writable binary buffer
                 (e.g. ``io.BytesIO``).
             password: Optional password to protect the workbook.
             autofit: Automatically adjust column widths (default ``True``).
@@ -165,7 +190,7 @@ class FastExcel:
                 Excel paths) autofit sizing is approximate. Set to
                 ``False`` for large datasets to improve performance.
         """
-        self._target = target
+        self._target = _coerce_target(target)
         self._password = password
         self._autofit = autofit
         self._sheets: List[Tuple[str, Any]] = []
@@ -174,6 +199,10 @@ class FastExcel:
         self._index_columns: Optional[List[str]] = None
         self._bold_headers: bool = False
         self._freeze_panes: Dict[str, Dict[str, int]] = {}
+        self._col_width: Dict[str, float] = {}
+        self._col_widths: Dict[str, Union[Dict[str, float], List[float]]] = {}
+        self._col_formats: Dict[str, Any] = {}
+        self._header_format: Dict[str, Any] = {}
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -238,17 +267,43 @@ class FastExcel:
 
     # -- data ---------------------------------------------------------------
 
-    def sheet(self, name: str, data: Any) -> "FastExcel":
+    def sheet(
+        self,
+        name: str,
+        data: Any,
+        *,
+        column_width: Optional[float] = None,
+        column_widths: Optional[Union[Dict[str, float], List[float]]] = None,
+        column_formats: Optional[Union[Dict[str, "Format"], List["Format"]]] = None,
+        header_format: Optional["Format"] = None,
+    ) -> "FastExcel":
         """Add a worksheet with data.
 
         Args:
             name: Sheet name (≤ 31 chars, no ``[ ] : * ? / \\``).
             data: List of dicts, generator of dicts, or pandas DataFrame.
+            column_width: Uniform width applied to every column of this sheet.
+            column_widths: Per-column width — a dict keyed by header name
+                (``{"name": 22}``) or a positional list (``[7, 22, 40]``).
+                Overrides ``column_width`` for the columns it names.
+            column_formats: Per-column :class:`Format` — a dict keyed by header
+                name (``{"name": Format().set_bold()}``) or a positional list
+                (``[Format().set_bold(), None]``).
+            header_format: :class:`Format` applied to every header cell of this
+                sheet.
 
         Raises:
             ValueError: If the sheet name is invalid (validated on save).
         """
         self._sheets.append((name, data))
+        if column_width is not None:
+            self._col_width[name] = column_width
+        if column_widths is not None:
+            self._col_widths[name] = column_widths
+        if column_formats is not None:
+            self._col_formats[name] = column_formats
+        if header_format is not None:
+            self._header_format[name] = header_format
         return self
 
     # -- output -------------------------------------------------------------
@@ -294,6 +349,9 @@ class FastExcel:
                 freeze_row = cfg.get("row")
                 freeze_col = cfg.get("col")
 
+            cw = self._col_width.get(sheet_name)
+            cws = self._col_widths.get(sheet_name)
+
             write_worksheet(
                 data,
                 self._target,
@@ -306,6 +364,10 @@ class FastExcel:
                 index_columns=self._index_columns,
                 autofit=self._autofit,
                 bold_headers=self._bold_headers,
+                column_width=cw,
+                column_widths=cws,
+                column_formats=self._col_formats.get(sheet_name),
+                header_format=self._header_format.get(sheet_name),
             )
         else:
             # Multi-sheet path
@@ -319,6 +381,10 @@ class FastExcel:
                 index_columns=self._index_columns,
                 autofit=self._autofit,
                 bold_headers=self._bold_headers,
+                column_width=self._col_width or None,
+                column_widths=self._col_widths or None,
+                column_formats=self._col_formats or None,
+                header_format=self._header_format or None,
             )
 
 
@@ -329,6 +395,8 @@ class FastExcel:
 __all__ = [
     # Class API
     "FastExcel",
+    # Format API
+    "Format",
     # Functional API
     "write_csv",
     "write_worksheet",

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -28,8 +28,10 @@ Records = Union[List[Record], Iterable[Record]]
 DataFrame = Any
 """A *pandas* or *polars* ``DataFrame`` – kept as ``Any`` to avoid a hard dependency."""
 
-FileTarget = Union[str, BinaryIO]
-"""A file path (``str``) or a writable binary buffer (e.g. ``io.BytesIO``)."""
+import os as _os
+
+FileTarget = Union[str, _os.PathLike, BinaryIO]
+"""A file path (``str`` / :class:`os.PathLike`) or a writable binary buffer (e.g. ``io.BytesIO``)."""
 
 FreezePanesConfig = Dict[str, Dict[str, int]]
 """Freeze-pane configuration.
@@ -42,6 +44,12 @@ Example::
     }
 """
 
+ColumnWidths = Union[Dict[str, float], List[float]]
+"""Per-column width — a dict keyed by header name or a positional list of widths."""
+
+ColumnFormats = Union[Dict[str, "Format"], List["Format"]]
+"""Per-column formats — a dict keyed by header name or a positional list of :class:`Format`."""
+
 SheetData = Union[Records, DataFrame]
 """Data accepted per sheet – either :data:`Records` or a :data:`DataFrame`."""
 
@@ -50,6 +58,70 @@ SheetMap = Dict[str, SheetData]
 
 SheetEntry = Tuple[str, SheetData]
 """A ``(sheet_name, data)`` pair as accepted by :func:`write_worksheets`."""
+
+# ---------------------------------------------------------------------------
+# Cell format
+# ---------------------------------------------------------------------------
+
+class Format:
+    """A reusable cell format (font, fill, border, alignment, number format).
+
+    Setters are chainable — each returns ``self``::
+
+        Format().set_bold().set_font_color("#FF0000").set_num_format("0.00%")
+
+    Colors accept ``"#RRGGBB"`` / ``"RRGGBB"`` hex or a color name
+    (e.g. ``"red"``). Enum-valued setters accept lowercase string names.
+    """
+
+    def __init__(self) -> None: ...
+    # Font
+    def set_bold(self) -> Format: ...
+    def set_italic(self) -> Format: ...
+    def set_underline(self, style: str = "single") -> Format: ...
+    def set_font_strikethrough(self) -> Format: ...
+    def set_font_size(self, size: float) -> Format: ...
+    def set_font_name(self, name: str) -> Format: ...
+    def set_font_color(self, color: str) -> Format: ...
+    def set_font_script(self, script: str) -> Format: ...
+    def set_font_family(self, n: int) -> Format: ...
+    def set_font_charset(self, n: int) -> Format: ...
+    def set_font_scheme(self, scheme: str) -> Format: ...
+    # Fill
+    def set_background_color(self, color: str) -> Format: ...
+    def set_foreground_color(self, color: str) -> Format: ...
+    def set_pattern(self, pattern: str) -> Format: ...
+    # Border
+    def set_border(self, style: str) -> Format: ...
+    def set_border_color(self, color: str) -> Format: ...
+    def set_border_top(self, style: str) -> Format: ...
+    def set_border_bottom(self, style: str) -> Format: ...
+    def set_border_left(self, style: str) -> Format: ...
+    def set_border_right(self, style: str) -> Format: ...
+    def set_border_top_color(self, color: str) -> Format: ...
+    def set_border_bottom_color(self, color: str) -> Format: ...
+    def set_border_left_color(self, color: str) -> Format: ...
+    def set_border_right_color(self, color: str) -> Format: ...
+    def set_border_diagonal(self, style: str) -> Format: ...
+    def set_border_diagonal_color(self, color: str) -> Format: ...
+    def set_border_diagonal_type(self, t: str) -> Format: ...
+    # Alignment / layout
+    def set_align(self, align: str) -> Format: ...
+    def set_text_wrap(self) -> Format: ...
+    def set_rotation(self, degrees: int) -> Format: ...
+    def set_indent(self, n: int) -> Format: ...
+    def set_shrink(self) -> Format: ...
+    def set_reading_direction(self, n: int) -> Format: ...
+    # Number
+    def set_num_format(self, fmt: str) -> Format: ...
+    def set_num_format_index(self, i: int) -> Format: ...
+    # Protection / misc
+    def set_locked(self) -> Format: ...
+    def set_unlocked(self) -> Format: ...
+    def set_hidden(self) -> Format: ...
+    def set_quote_prefix(self) -> Format: ...
+    def set_checkbox(self) -> Format: ...
+    def set_hyperlink(self) -> Format: ...
 
 # ---------------------------------------------------------------------------
 # Builder class
@@ -137,13 +209,28 @@ class FastExcel:
         """
         ...
 
-    def sheet(self, name: str, data: SheetData) -> FastExcel:
+    def sheet(
+        self,
+        name: str,
+        data: SheetData,
+        *,
+        column_width: Optional[float] = None,
+        column_widths: Optional[ColumnWidths] = None,
+        column_formats: Optional[ColumnFormats] = None,
+        header_format: Optional[Format] = None,
+    ) -> FastExcel:
         """Add a worksheet with data.
 
         Args:
             name: Sheet name (≤ 31 chars, no ``[ ] : * ? / \\``).
             data: List of dicts, generator of dicts, pandas DataFrame,
                 or polars DataFrame.
+            column_width: Uniform width applied to every column of this sheet.
+            column_widths: Per-column width — a dict keyed by header name
+                or a positional list of widths.
+            column_formats: Per-column :class:`Format` — a dict keyed by header
+                name or a positional list.
+            header_format: A :class:`Format` applied to the header row.
 
         Raises:
             ValueError: If the sheet name is invalid.
@@ -175,6 +262,10 @@ def write_worksheet(
     index_columns: Optional[List[str]] = None,
     autofit: bool = True,
     bold_headers: bool = False,
+    column_width: Optional[float] = None,
+    column_widths: Optional[ColumnWidths] = None,
+    column_formats: Optional[ColumnFormats] = None,
+    header_format: Optional[Format] = None,
 ) -> None:
     """Write data to a **single** worksheet in an Excel file.
 
@@ -191,6 +282,8 @@ def write_worksheet(
         float_format: Excel number format for floats (e.g. ``"0.00"``).
         index_columns: Column names that should be rendered **bold**.
         autofit: Automatically adjust column widths (default ``True``).
+        column_width: Uniform width applied to every column.
+        column_widths: Per-column width — a dict keyed by header name or a positional list.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -211,6 +304,10 @@ def write_worksheets(
     index_columns: Optional[List[str]] = None,
     autofit: bool = True,
     bold_headers: bool = False,
+    column_width: Optional[Dict[str, float]] = None,
+    column_widths: Optional[Dict[str, ColumnWidths]] = None,
+    column_formats: Optional[Dict[str, ColumnFormats]] = None,
+    header_format: Optional[Dict[str, Format]] = None,
 ) -> None:
     """Write data to **multiple** worksheets in an Excel file.
 
@@ -222,6 +319,8 @@ def write_worksheets(
         float_format: Excel number format for floats (e.g. ``"0.00"``).
         index_columns: Column names that should be rendered **bold**.
         autofit: Automatically adjust column widths (default ``True``).
+        column_width: Uniform width per sheet — dict keyed by sheet name (``"general"`` applies to all).
+        column_widths: Per-column width per sheet — dict keyed by sheet name mapping to :data:`ColumnWidths`.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -279,7 +378,7 @@ def validate_sheet_name(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def get_version() -> str:
-    """Return the package version string (e.g. ``'0.4.4'``)."""
+    """Return the package version string (e.g. ``'0.5.0'``)."""
     ...
 
 def get_name() -> str:
@@ -306,12 +405,16 @@ def get_license() -> str:
     """Return the license identifier (``'MIT'``)."""
     ...
 
+__version__: str
+"""Package version string — same value as :func:`get_version`."""
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 __all__ = [
     "FastExcel",
+    "Format",
     "write_csv",
     "write_worksheet",
     "write_worksheets",
@@ -328,7 +431,10 @@ __all__ = [
     "DataFrame",
     "FileTarget",
     "FreezePanesConfig",
+    "ColumnWidths",
+    "ColumnFormats",
     "SheetData",
     "SheetEntry",
     "SheetMap",
+    "__version__",
 ]

--- a/src/arrow_writer.rs
+++ b/src/arrow_writer.rs
@@ -5,6 +5,7 @@ use arrow_schema::{DataType, TimeUnit};
 use pyo3::prelude::*;
 use rust_xlsxwriter::{ExcelDateTime, Format, Worksheet};
 
+use crate::helpers::write_csv_escaped;
 use crate::worksheet::xlsx_err;
 
 /// Column type classification done once (outside the row loop) to avoid
@@ -77,11 +78,17 @@ fn write_float(
 
 /// Write an Arrow `RecordBatch` starting at `start_row`.
 /// Column types are classified once; each cell dispatches on the cached kind.
+///
+/// `col_formats` is a per-column slice of optional `Format`s resolved from
+/// `column_formats`. When a column has an explicit format, it wins over
+/// `float_fmt` for numeric columns. Pass an empty slice when no overrides
+/// are needed (byte-identical behaviour).
 pub fn write_arrow_batch(
     worksheet: &mut Worksheet,
     batch: &RecordBatch,
     start_row: u32,
     float_fmt: Option<&Format>,
+    col_formats: &[Option<crate::format::Format>],
 ) -> PyResult<()> {
     let num_cols = batch.num_columns();
     let num_rows = batch.num_rows();
@@ -95,6 +102,10 @@ pub fn write_arrow_batch(
             let col_u16 = col_idx as u16;
             let column = &columns[col_idx];
 
+            // Per-column format override: wins over float_fmt for numeric cols.
+            let col_override: Option<&Format> =
+                col_formats.get(col_idx).and_then(|o| o.as_ref()).map(|f| &f.inner);
+
             if column.is_null(row) {
                 worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
                 continue;
@@ -103,7 +114,11 @@ pub fn write_arrow_batch(
             macro_rules! write_int {
                 ($ty:ty) => {{
                     let val = column.as_primitive::<$ty>().value(row) as f64;
-                    worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    if let Some(fmt) = col_override {
+                        worksheet.write_number_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
+                    } else {
+                        worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    }
                 }};
             }
 
@@ -118,15 +133,19 @@ pub fn write_arrow_batch(
                 ColKind::UInt64 => write_int!(UInt64Type),
                 ColKind::Float16 => {
                     let val = column.as_primitive::<Float16Type>().value(row).to_f64();
-                    worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    if let Some(fmt) = col_override {
+                        worksheet.write_number_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
+                    } else {
+                        worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    }
                 }
                 ColKind::Float32 => {
                     let val = column.as_primitive::<Float32Type>().value(row) as f64;
-                    write_float(worksheet, row_u32, col_u16, val, float_fmt)?;
+                    write_float(worksheet, row_u32, col_u16, val, col_override.or(float_fmt))?;
                 }
                 ColKind::Float64 => {
                     let val = column.as_primitive::<Float64Type>().value(row);
-                    write_float(worksheet, row_u32, col_u16, val, float_fmt)?;
+                    write_float(worksheet, row_u32, col_u16, val, col_override.or(float_fmt))?;
                 }
                 ColKind::Bool => {
                     let arr = column
@@ -139,15 +158,27 @@ pub fn write_arrow_batch(
                 }
                 ColKind::Utf8 => {
                     let val = column.as_string::<i32>().value(row);
-                    worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    if let Some(fmt) = col_override {
+                        worksheet.write_string_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
+                    } else {
+                        worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    }
                 }
                 ColKind::LargeUtf8 => {
                     let val = column.as_string::<i64>().value(row);
-                    worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    if let Some(fmt) = col_override {
+                        worksheet.write_string_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
+                    } else {
+                        worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    }
                 }
                 ColKind::Utf8View => {
                     let val = column.as_string_view().value(row);
-                    worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    if let Some(fmt) = col_override {
+                        worksheet.write_string_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
+                    } else {
+                        worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
+                    }
                 }
                 ColKind::Date32 => {
                     let days = column.as_primitive::<Date32Type>().value(row);
@@ -328,25 +359,6 @@ fn emit_timestamp_csv(output: &mut Vec<u8>, micros: i64) {
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
         y, m, d, hour, minute, second
     );
-}
-
-fn write_csv_escaped(output: &mut Vec<u8>, val: &str) {
-    if val.contains(',')
-        || val.contains('\n')
-        || val.contains('\r')
-        || val.contains('"')
-    {
-        output.push(b'"');
-        for b in val.bytes() {
-            if b == b'"' {
-                output.push(b'"');
-            }
-            output.push(b);
-        }
-        output.push(b'"');
-    } else {
-        output.extend_from_slice(val.as_bytes());
-    }
 }
 
 pub fn set_datetime_column_formats(

--- a/src/csv_writer.rs
+++ b/src/csv_writer.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateAccess, PyDateTime, PyTimeAccess};
 use pyo3::Py;
 
-use crate::helpers::write_bytes_to_target;
+use crate::helpers::{write_bytes_to_target, write_csv_escaped, ColType};
 
 /// Write data to CSV (file path or buffer).
 #[pyfunction]
@@ -89,9 +89,12 @@ pub fn write_csv(
             }
         }
     } else {
-        // Records path (list of dicts / generator)
+        // Records path (list of dicts / generator). First-row type cache
+        // mirrors the Excel Records path — skips the full type cascade
+        // after the first row when the column's Python type is stable.
         let mut headers: Vec<String> = Vec::new();
         let mut headers_written = false;
+        let mut col_types: Vec<ColType> = Vec::new();
 
         if let Ok(rows) = bound.try_iter() {
             for row_res in rows {
@@ -107,16 +110,22 @@ pub fn write_csv(
                         headers.push(key.extract::<String>()?);
                     }
                     write_csv_row_strings(&mut output, &headers, delim_byte);
+                    col_types.resize(headers.len(), ColType::Unknown);
                     headers_written = true;
                 }
 
-                let mut first = true;
-                for value in row_dict.values().iter() {
-                    if !first {
+                for (col, value) in row_dict.values().iter().enumerate() {
+                    if col > 0 {
                         output.push(delim_byte);
                     }
-                    first = false;
-                    write_csv_value(&mut output, &value)?;
+                    let cached = col_types.get(col).copied().unwrap_or(ColType::Unknown);
+                    let hit = try_cached_csv_value(&mut output, &value, cached)?;
+                    if !hit {
+                        let detected = write_csv_value(&mut output, &value)?;
+                        if col < col_types.len() && col_types[col] == ColType::Unknown {
+                            col_types[col] = detected;
+                        }
+                    }
                 }
                 output.push(b'\n');
             }
@@ -163,96 +172,156 @@ fn write_csv_row_strings(output: &mut Vec<u8>, values: &[String], delim: u8) {
     output.push(b'\n');
 }
 
-fn write_csv_value(output: &mut Vec<u8>, value: &Bound<PyAny>) -> PyResult<()> {
+fn emit_string(output: &mut Vec<u8>, s: &str) {
+    write_csv_escaped(output, s);
+}
+
+fn emit_bool(output: &mut Vec<u8>, b: bool) {
+    output.extend_from_slice(if b { b"true" } else { b"false" });
+}
+
+fn emit_float(output: &mut Vec<u8>, val: f64) {
+    if !val.is_nan() && !val.is_infinite() {
+        let mut buf = ryu::Buffer::new();
+        output.extend_from_slice(buf.format(val).as_bytes());
+    }
+}
+
+fn emit_int(output: &mut Vec<u8>, val: i64) {
+    let mut buf = itoa::Buffer::new();
+    output.extend_from_slice(buf.format(val).as_bytes());
+}
+
+fn emit_datetime(output: &mut Vec<u8>, dt: &Bound<PyDateTime>) {
+    let _ = write!(
+        output,
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+        dt.get_year(),
+        dt.get_month(),
+        dt.get_day(),
+        dt.get_hour(),
+        dt.get_minute(),
+        dt.get_second()
+    );
+}
+
+fn emit_date(output: &mut Vec<u8>, d: &Bound<PyDate>) {
+    let _ = write!(
+        output,
+        "{:04}-{:02}-{:02}",
+        d.get_year(),
+        d.get_month(),
+        d.get_day()
+    );
+}
+
+/// Try the cached column type. Returns `true` if the value matched and was
+/// written; `false` if the cache was empty or the value's type didn't match
+/// (caller then falls back to the full cascade).
+fn try_cached_csv_value(
+    output: &mut Vec<u8>,
+    value: &Bound<PyAny>,
+    cached: ColType,
+) -> PyResult<bool> {
     if value.is_none() {
-        return Ok(());
+        return Ok(true);
+    }
+    match cached {
+        ColType::String => {
+            if let Ok(s) = value.cast::<pyo3::types::PyString>() {
+                emit_string(output, s.to_str()?);
+                return Ok(true);
+            }
+        }
+        ColType::Bool => {
+            if let Ok(b) = value.cast::<pyo3::types::PyBool>() {
+                emit_bool(output, b.is_true());
+                return Ok(true);
+            }
+        }
+        ColType::Float => {
+            if let Ok(f) = value.cast::<pyo3::types::PyFloat>() {
+                emit_float(output, f.value());
+                return Ok(true);
+            }
+        }
+        ColType::Int => {
+            // Python bool is a subclass of int and casts to PyInt, so a bool
+            // landing in an Int-cached column must miss here and fall back to
+            // the cascade (which checks Bool first) — else `True` → `1`.
+            if value.cast::<pyo3::types::PyBool>().is_err() {
+                if let Ok(i) = value.cast::<pyo3::types::PyInt>() {
+                    emit_int(output, i.extract()?);
+                    return Ok(true);
+                }
+            }
+        }
+        ColType::DateTime => {
+            if let Ok(dt) = value.cast::<PyDateTime>() {
+                emit_datetime(output, &dt);
+                return Ok(true);
+            }
+        }
+        ColType::Date => {
+            if let Ok(d) = value.cast::<PyDate>() {
+                emit_date(output, &d);
+                return Ok(true);
+            }
+        }
+        ColType::Unknown => {}
+    }
+    Ok(false)
+}
+
+fn write_csv_value(output: &mut Vec<u8>, value: &Bound<PyAny>) -> PyResult<ColType> {
+    if value.is_none() {
+        return Ok(ColType::Unknown);
     }
 
     if let Ok(s) = value.cast::<pyo3::types::PyString>() {
-        write_csv_escaped(output, s.to_str()?);
-        return Ok(());
+        emit_string(output, s.to_str()?);
+        return Ok(ColType::String);
     }
 
+    // Bool BEFORE Int (Python bool is subclass of int)
     if let Ok(b) = value.cast::<pyo3::types::PyBool>() {
-        output.extend_from_slice(if b.is_true() { b"true" } else { b"false" });
-        return Ok(());
+        emit_bool(output, b.is_true());
+        return Ok(ColType::Bool);
     }
 
     if let Ok(f) = value.cast::<pyo3::types::PyFloat>() {
-        let val = f.value();
-        if val.is_nan() || val.is_infinite() {
-            return Ok(());
-        }
-        let mut buf = ryu::Buffer::new();
-        output.extend_from_slice(buf.format(val).as_bytes());
-        return Ok(());
+        emit_float(output, f.value());
+        return Ok(ColType::Float);
     }
 
     if let Ok(i) = value.cast::<pyo3::types::PyInt>() {
-        let val: i64 = i.extract()?;
-        let mut buf = itoa::Buffer::new();
-        output.extend_from_slice(buf.format(val).as_bytes());
-        return Ok(());
+        emit_int(output, i.extract()?);
+        return Ok(ColType::Int);
     }
 
     if let Ok(dt) = value.cast::<PyDateTime>() {
-        write!(
-            output,
-            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
-            dt.get_year(),
-            dt.get_month(),
-            dt.get_day(),
-            dt.get_hour(),
-            dt.get_minute(),
-            dt.get_second()
-        )
-        .expect("write to Vec<u8> is infallible");
-        return Ok(());
+        emit_datetime(output, &dt);
+        return Ok(ColType::DateTime);
     }
 
+    // Date AFTER DateTime (datetime is subclass of date)
     if let Ok(d) = value.cast::<PyDate>() {
-        write!(
-            output,
-            "{:04}-{:02}-{:02}",
-            d.get_year(),
-            d.get_month(),
-            d.get_day()
-        )
-        .expect("write to Vec<u8> is infallible");
-        return Ok(());
+        emit_date(output, &d);
+        return Ok(ColType::Date);
     }
 
     // numpy scalar fallback: bool before f64
     if let Ok(val) = value.extract::<bool>() {
-        output.extend_from_slice(if val { b"true" } else { b"false" });
-        return Ok(());
+        emit_bool(output, val);
+        return Ok(ColType::Bool);
     }
 
     if let Ok(val) = value.extract::<f64>() {
-        if !val.is_nan() && !val.is_infinite() {
-            let mut buf = ryu::Buffer::new();
-            output.extend_from_slice(buf.format(val).as_bytes());
-        }
-        return Ok(());
+        emit_float(output, val);
+        return Ok(ColType::Float);
     }
 
-    let s = value.to_string();
-    write_csv_escaped(output, &s);
-    Ok(())
+    emit_string(output, &value.to_string());
+    Ok(ColType::String)
 }
 
-/// Escape per RFC 4180: quote if value contains delimiter-relevant chars.
-fn write_csv_escaped(output: &mut Vec<u8>, val: &str) {
-    if val.contains(',') || val.contains('\n') || val.contains('\r') || val.contains('"') {
-        output.push(b'"');
-        for b in val.bytes() {
-            if b == b'"' {
-                output.push(b'"');
-            }
-            output.push(b);
-        }
-        output.push(b'"');
-    } else {
-        output.extend_from_slice(val.as_bytes());
-    }
-}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,576 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use rust_xlsxwriter::{
+    Color, Format as XlsxFormat, FontScheme, FormatAlign, FormatBorder, FormatDiagonalBorder,
+    FormatPattern, FormatScript, FormatUnderline,
+};
+
+/// Parse a color string: `#RRGGBB` / `RRGGBB` hex, or a common color name.
+pub fn parse_color(s: &str) -> PyResult<Color> {
+    let t = s.trim();
+    let named = match t.to_ascii_lowercase().as_str() {
+        "black" => Some(Color::Black),
+        "blue" => Some(Color::Blue),
+        "brown" => Some(Color::Brown),
+        "cyan" => Some(Color::Cyan),
+        "gray" | "grey" => Some(Color::Gray),
+        "green" => Some(Color::Green),
+        "lime" => Some(Color::Lime),
+        "magenta" => Some(Color::Magenta),
+        "navy" => Some(Color::Navy),
+        "orange" => Some(Color::Orange),
+        "pink" => Some(Color::Pink),
+        "purple" => Some(Color::Purple),
+        "red" => Some(Color::Red),
+        "silver" => Some(Color::Silver),
+        "white" => Some(Color::White),
+        "yellow" => Some(Color::Yellow),
+        "automatic" => Some(Color::Automatic),
+        _ => None,
+    };
+    if let Some(c) = named {
+        return Ok(c);
+    }
+    let hex = t.strip_prefix('#').unwrap_or(t);
+    if hex.len() == 6 {
+        if let Ok(rgb) = u32::from_str_radix(hex, 16) {
+            return Ok(Color::RGB(rgb));
+        }
+    }
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "invalid color '{s}' (expected '#RRGGBB', 'RRGGBB', or a color name)"
+    )))
+}
+
+fn parse_align(s: &str) -> PyResult<FormatAlign> {
+    Ok(match s.to_ascii_lowercase().as_str() {
+        "general" => FormatAlign::General,
+        "left" => FormatAlign::Left,
+        "center" => FormatAlign::Center,
+        "right" => FormatAlign::Right,
+        "fill" => FormatAlign::Fill,
+        "justify" => FormatAlign::Justify,
+        "center_across" => FormatAlign::CenterAcross,
+        "distributed" => FormatAlign::Distributed,
+        "top" => FormatAlign::Top,
+        "bottom" => FormatAlign::Bottom,
+        "vcenter" | "vertical_center" => FormatAlign::VerticalCenter,
+        "vjustify" | "vertical_justify" => FormatAlign::VerticalJustify,
+        "vdistributed" | "vertical_distributed" => FormatAlign::VerticalDistributed,
+        other => {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "invalid align '{other}' (valid: general, left, center, right, fill, \
+                 justify, center_across, distributed, top, bottom, vcenter, vjustify, \
+                 vdistributed; also: vertical_center, vertical_justify, vertical_distributed)"
+            )))
+        }
+    })
+}
+
+fn parse_border(s: &str) -> PyResult<FormatBorder> {
+    Ok(match s.to_ascii_lowercase().as_str() {
+        "none" => FormatBorder::None,
+        "thin" => FormatBorder::Thin,
+        "medium" => FormatBorder::Medium,
+        "dashed" => FormatBorder::Dashed,
+        "dotted" => FormatBorder::Dotted,
+        "thick" => FormatBorder::Thick,
+        "double" => FormatBorder::Double,
+        "hair" => FormatBorder::Hair,
+        "medium_dashed" => FormatBorder::MediumDashed,
+        "dash_dot" => FormatBorder::DashDot,
+        "medium_dash_dot" => FormatBorder::MediumDashDot,
+        "dash_dot_dot" => FormatBorder::DashDotDot,
+        "medium_dash_dot_dot" => FormatBorder::MediumDashDotDot,
+        "slant_dash_dot" => FormatBorder::SlantDashDot,
+        other => {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "invalid border '{other}' (valid: none, thin, medium, dashed, dotted, \
+                 thick, double, hair, medium_dashed, dash_dot, medium_dash_dot, \
+                 dash_dot_dot, medium_dash_dot_dot, slant_dash_dot)"
+            )))
+        }
+    })
+}
+
+fn parse_pattern(s: &str) -> PyResult<FormatPattern> {
+    Ok(match s.to_ascii_lowercase().as_str() {
+        "none" => FormatPattern::None,
+        "solid" => FormatPattern::Solid,
+        "medium_gray" => FormatPattern::MediumGray,
+        "dark_gray" => FormatPattern::DarkGray,
+        "light_gray" => FormatPattern::LightGray,
+        "dark_horizontal" => FormatPattern::DarkHorizontal,
+        "dark_vertical" => FormatPattern::DarkVertical,
+        "dark_down" => FormatPattern::DarkDown,
+        "dark_up" => FormatPattern::DarkUp,
+        "dark_grid" => FormatPattern::DarkGrid,
+        "dark_trellis" => FormatPattern::DarkTrellis,
+        "light_horizontal" => FormatPattern::LightHorizontal,
+        "light_vertical" => FormatPattern::LightVertical,
+        "light_down" => FormatPattern::LightDown,
+        "light_up" => FormatPattern::LightUp,
+        "light_grid" => FormatPattern::LightGrid,
+        "light_trellis" => FormatPattern::LightTrellis,
+        "gray125" => FormatPattern::Gray125,
+        "gray0625" => FormatPattern::Gray0625,
+        other => {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "invalid pattern '{other}' (valid: none, solid, medium_gray, dark_gray, \
+                 light_gray, dark_horizontal, dark_vertical, dark_down, dark_up, dark_grid, \
+                 dark_trellis, light_horizontal, light_vertical, light_down, light_up, \
+                 light_grid, light_trellis, gray125, gray0625)"
+            )))
+        }
+    })
+}
+
+fn parse_underline(s: &str) -> PyResult<FormatUnderline> {
+    Ok(match s.to_ascii_lowercase().as_str() {
+        "none" => FormatUnderline::None,
+        "single" => FormatUnderline::Single,
+        "double" => FormatUnderline::Double,
+        "single_accounting" => FormatUnderline::SingleAccounting,
+        "double_accounting" => FormatUnderline::DoubleAccounting,
+        other => {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "invalid underline '{other}' (valid: none, single, double, \
+                 single_accounting, double_accounting)"
+            )))
+        }
+    })
+}
+
+fn parse_script(s: &str) -> PyResult<FormatScript> {
+    Ok(match s.to_ascii_lowercase().as_str() {
+        "none" => FormatScript::None,
+        "super" | "superscript" => FormatScript::Superscript,
+        "sub" | "subscript" => FormatScript::Subscript,
+        other => {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "invalid script '{other}' (valid: none, super, superscript, sub, subscript)"
+            )))
+        }
+    })
+}
+
+fn parse_diagonal_type(s: &str) -> PyResult<FormatDiagonalBorder> {
+    Ok(match s.to_ascii_lowercase().as_str() {
+        "none" => FormatDiagonalBorder::None,
+        "border_up" => FormatDiagonalBorder::BorderUp,
+        "border_down" => FormatDiagonalBorder::BorderDown,
+        "border_up_down" => FormatDiagonalBorder::BorderUpDown,
+        other => {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "invalid diagonal_type '{other}' (valid: none, border_up, border_down, border_up_down)"
+            )))
+        }
+    })
+}
+
+fn parse_font_scheme(s: &str) -> PyResult<FontScheme> {
+    Ok(match s.to_ascii_lowercase().as_str() {
+        "none" => FontScheme::None,
+        "body" => FontScheme::Body,
+        "headings" | "heading" => FontScheme::Headings,
+        other => {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "invalid font_scheme '{other}' (valid: none, body, headings)"
+            )))
+        }
+    })
+}
+
+/// Python-facing cell format. Chainable; each setter returns `self`.
+#[pyclass(from_py_object)]
+#[derive(Clone)]
+pub struct Format {
+    pub inner: XlsxFormat,
+}
+
+#[pymethods]
+impl Format {
+    #[new]
+    fn new() -> Self {
+        Format {
+            inner: XlsxFormat::new(),
+        }
+    }
+
+    fn set_bold(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_bold();
+        slf
+    }
+
+    fn set_italic(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_italic();
+        slf
+    }
+
+    fn set_font_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_font_color(c);
+        Ok(slf)
+    }
+
+    fn set_background_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_background_color(c);
+        Ok(slf)
+    }
+
+    fn set_num_format<'p>(mut slf: PyRefMut<'p, Self>, format: &str) -> PyRefMut<'p, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_num_format(format);
+        slf
+    }
+
+    fn set_align<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        align: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let a = parse_align(align)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_align(a);
+        Ok(slf)
+    }
+
+    fn set_border<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        style: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let b = parse_border(style)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border(b);
+        Ok(slf)
+    }
+
+    // ── No-arg bool (infallible) ──────────────────────────────────────────────
+
+    fn set_text_wrap(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_text_wrap();
+        slf
+    }
+
+    fn set_shrink(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_shrink();
+        slf
+    }
+
+    fn set_font_strikethrough(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_font_strikethrough();
+        slf
+    }
+
+    fn set_locked(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_locked();
+        slf
+    }
+
+    fn set_unlocked(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_unlocked();
+        slf
+    }
+
+    fn set_hidden(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_hidden();
+        slf
+    }
+
+    fn set_quote_prefix(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_quote_prefix();
+        slf
+    }
+
+    fn set_checkbox(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_checkbox();
+        slf
+    }
+
+    fn set_hyperlink(mut slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_hyperlink();
+        slf
+    }
+
+    // ── Numeric arg (infallible) ──────────────────────────────────────────────
+
+    fn set_font_size(mut slf: PyRefMut<'_, Self>, size: f64) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_font_size(size);
+        slf
+    }
+
+    fn set_font_family(mut slf: PyRefMut<'_, Self>, n: u8) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_font_family(n);
+        slf
+    }
+
+    fn set_font_charset(mut slf: PyRefMut<'_, Self>, n: u8) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_font_charset(n);
+        slf
+    }
+
+    fn set_rotation(mut slf: PyRefMut<'_, Self>, degrees: i16) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_rotation(degrees);
+        slf
+    }
+
+    fn set_indent(mut slf: PyRefMut<'_, Self>, n: u8) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_indent(n);
+        slf
+    }
+
+    fn set_reading_direction(mut slf: PyRefMut<'_, Self>, n: u8) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_reading_direction(n);
+        slf
+    }
+
+    fn set_num_format_index(mut slf: PyRefMut<'_, Self>, i: u8) -> PyRefMut<'_, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_num_format_index(i);
+        slf
+    }
+
+    // ── String passthrough (infallible) ──────────────────────────────────────
+
+    fn set_font_name<'p>(mut slf: PyRefMut<'p, Self>, name: &str) -> PyRefMut<'p, Self> {
+        slf.inner = std::mem::take(&mut slf.inner).set_font_name(name);
+        slf
+    }
+
+    fn set_font_scheme<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        scheme: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let s = parse_font_scheme(scheme)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_font_scheme(s);
+        Ok(slf)
+    }
+
+    // ── Color arg (fallible) ──────────────────────────────────────────────────
+
+    fn set_foreground_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_foreground_color(c);
+        Ok(slf)
+    }
+
+    fn set_border_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_color(c);
+        Ok(slf)
+    }
+
+    fn set_border_top_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_top_color(c);
+        Ok(slf)
+    }
+
+    fn set_border_bottom_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_bottom_color(c);
+        Ok(slf)
+    }
+
+    fn set_border_left_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_left_color(c);
+        Ok(slf)
+    }
+
+    fn set_border_right_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_right_color(c);
+        Ok(slf)
+    }
+
+    fn set_border_diagonal_color<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        color: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let c = parse_color(color)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_diagonal_color(c);
+        Ok(slf)
+    }
+
+    // ── Enum arg (fallible) ───────────────────────────────────────────────────
+
+    #[pyo3(signature = (style = "single"))]
+    fn set_underline<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        style: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let u = parse_underline(style)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_underline(u);
+        Ok(slf)
+    }
+
+    fn set_font_script<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        script: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let s = parse_script(script)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_font_script(s);
+        Ok(slf)
+    }
+
+    fn set_pattern<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        pattern: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let p = parse_pattern(pattern)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_pattern(p);
+        Ok(slf)
+    }
+
+    fn set_border_top<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        style: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let b = parse_border(style)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_top(b);
+        Ok(slf)
+    }
+
+    fn set_border_bottom<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        style: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let b = parse_border(style)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_bottom(b);
+        Ok(slf)
+    }
+
+    fn set_border_left<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        style: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let b = parse_border(style)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_left(b);
+        Ok(slf)
+    }
+
+    fn set_border_right<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        style: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let b = parse_border(style)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_right(b);
+        Ok(slf)
+    }
+
+    fn set_border_diagonal<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        style: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let b = parse_border(style)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_diagonal(b);
+        Ok(slf)
+    }
+
+    fn set_border_diagonal_type<'p>(
+        mut slf: PyRefMut<'p, Self>,
+        dtype: &str,
+    ) -> PyResult<PyRefMut<'p, Self>> {
+        let d = parse_diagonal_type(dtype)?;
+        slf.inner = std::mem::take(&mut slf.inner).set_border_diagonal_type(d);
+        Ok(slf)
+    }
+}
+
+/// Apply resolved per-column formats to the worksheet via `set_column_format`.
+/// Must be called BEFORE data rows are written (constant-memory mode).
+pub fn apply_column_formats(
+    worksheet: &mut rust_xlsxwriter::Worksheet,
+    col_formats: &[Option<Format>],
+) -> PyResult<()> {
+    for (col, fmt) in col_formats.iter().enumerate() {
+        if let Some(f) = fmt {
+            worksheet
+                .set_column_format(col as u16, &f.inner)
+                .map_err(crate::worksheet::xlsx_err)?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve `column_formats` (dict by header name or positional list of Format)
+/// into a per-column `Vec<Option<Format>>` aligned to `headers`. Unknown dict
+/// names warn and are skipped. A non-Format value raises `TypeError`.
+pub fn resolve_column_formats(
+    spec: Option<&Bound<'_, PyAny>>,
+    headers: &[String],
+    py: Python,
+) -> PyResult<Vec<Option<Format>>> {
+    let mut out: Vec<Option<Format>> = vec![None; headers.len()];
+    let Some(spec) = spec else { return Ok(out) };
+
+    let warnings = py.import("warnings")?;
+
+    if let Ok(dict) = spec.cast::<PyDict>() {
+        for (key, val) in dict.iter() {
+            let name: String = key.extract()?;
+            let fmt: Format = val.extract().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "column_formats values must be Format objects",
+                )
+            })?;
+            match headers.iter().position(|h| h == &name) {
+                Some(idx) => out[idx] = Some(fmt),
+                None => {
+                    warnings.call_method1(
+                        "warn",
+                        (format!("column_formats: unknown column '{name}', skipped"),),
+                    )?;
+                }
+            }
+        }
+    } else if let Ok(list) = spec.cast::<PyList>() {
+        for (idx, item) in list.iter().enumerate() {
+            if idx >= out.len() {
+                warnings.call_method1(
+                    "warn",
+                    (format!(
+                        "column_formats: index {idx} out of range ({} columns), skipped",
+                        out.len()
+                    ),),
+                )?;
+                continue;
+            }
+            if item.is_none() {
+                continue;
+            }
+            let fmt: Format = item.extract().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "column_formats values must be Format objects or None",
+                )
+            })?;
+            out[idx] = Some(fmt);
+        }
+    } else {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "column_formats must be a dict (by column name) or a list (positional)",
+        ));
+    }
+    Ok(out)
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for Excel/CSV writing paths.
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDate, PyDateAccess, PyDateTime, PyTimeAccess};
+use pyo3::types::{PyDate, PyDateAccess, PyDateTime, PyDict, PyList, PyTimeAccess};
 use pyo3::Py;
 use rust_xlsxwriter::{ExcelDateTime, Format, Workbook, Worksheet};
 
@@ -65,6 +65,7 @@ pub fn py_date_to_excel(d: &Bound<PyDate>) -> PyResult<ExcelDateTime> {
 
 /// Write a header cell at row 0, optionally bold, and mark the column
 /// as an index (bold) column if listed in `index_columns`.
+/// When `header_fmt` is `Some`, it wins over `bold_headers` for the cell itself.
 pub fn write_header(
     worksheet: &mut Worksheet,
     col: u16,
@@ -72,7 +73,14 @@ pub fn write_header(
     bold_headers: bool,
     bold_fmt: &Format,
     index_columns: Option<&Vec<String>>,
+    header_fmt: Option<&Format>,
 ) -> PyResult<()> {
+    if let Some(fmt) = header_fmt {
+        worksheet
+            .write_string_with_format(0, col, header, fmt)
+            .map_err(xlsx_err)?;
+        return Ok(());
+    }
     if bold_headers {
         worksheet
             .write_string_with_format(0, col, header, bold_fmt)
@@ -108,6 +116,23 @@ pub fn write_num(
         worksheet.write_number(row, col, val).map_err(xlsx_err)?;
     }
     Ok(())
+}
+
+/// Escape per RFC 4180: wrap in quotes if value contains delim-relevant
+/// chars (comma, newline, CR, quote) and double any internal quote.
+pub fn write_csv_escaped(output: &mut Vec<u8>, val: &str) {
+    if val.contains(',') || val.contains('\n') || val.contains('\r') || val.contains('"') {
+        output.push(b'"');
+        for b in val.bytes() {
+            if b == b'"' {
+                output.push(b'"');
+            }
+            output.push(b);
+        }
+        output.push(b'"');
+    } else {
+        output.extend_from_slice(val.as_bytes());
+    }
 }
 
 /// Save a workbook to a file path or writable buffer.
@@ -157,4 +182,99 @@ pub fn write_bytes_to_target(
     Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
         "Argument must be a string path or a file-like object with a 'write' method",
     ))
+}
+
+/// `true` if `w` is a usable Excel column width (finite, non-negative).
+fn is_valid_width(w: f64) -> bool {
+    w.is_finite() && w >= 0.0
+}
+
+/// Emit a Python `UserWarning` from Rust.
+fn warn_py(py: Python, msg: &str) -> PyResult<()> {
+    py.import("warnings")?.call_method1("warn", (msg,))?;
+    Ok(())
+}
+
+/// Apply explicit column widths AFTER `autofit()` so they override it.
+///
+/// `uniform` (from `column_width`) sets every column as a base layer;
+/// `spec` (from `column_widths`) then overrides individual columns —
+/// a dict keyed by header name, or a positional list. Unknown names,
+/// out-of-range list indices, and invalid widths emit a `UserWarning`
+/// and are skipped. An unsupported `spec` type raises `ValueError`.
+pub fn apply_column_widths(
+    worksheet: &mut Worksheet,
+    headers: &[String],
+    uniform: Option<f64>,
+    spec: Option<&Bound<'_, PyAny>>,
+    py: Python,
+) -> PyResult<()> {
+    let ncols = headers.len() as u16;
+
+    if let Some(w) = uniform {
+        if is_valid_width(w) {
+            if ncols > 0 {
+                worksheet
+                    .set_column_range_width(0, ncols - 1, w)
+                    .map_err(xlsx_err)?;
+            }
+        } else {
+            warn_py(py, &format!("column_width: invalid width {w}, skipped"))?;
+        }
+    }
+
+    let Some(spec) = spec else {
+        return Ok(());
+    };
+
+    if let Ok(dict) = spec.cast::<PyDict>() {
+        for (key, val) in dict.iter() {
+            let name: String = key.extract()?;
+            let width: f64 = val.extract()?;
+            match headers.iter().position(|h| h == &name) {
+                Some(idx) if is_valid_width(width) => {
+                    worksheet
+                        .set_column_width(idx as u16, width)
+                        .map_err(xlsx_err)?;
+                }
+                Some(_) => warn_py(
+                    py,
+                    &format!("column_widths: invalid width {width} for '{name}', skipped"),
+                )?,
+                None => warn_py(
+                    py,
+                    &format!("column_widths: unknown column '{name}', skipped"),
+                )?,
+            }
+        }
+    } else if let Ok(list) = spec.cast::<PyList>() {
+        for (idx, item) in list.iter().enumerate() {
+            let width: f64 = item.extract()?;
+            if idx as u16 >= ncols {
+                warn_py(
+                    py,
+                    &format!(
+                        "column_widths: index {idx} out of range ({ncols} columns), skipped"
+                    ),
+                )?;
+                continue;
+            }
+            if is_valid_width(width) {
+                worksheet
+                    .set_column_width(idx as u16, width)
+                    .map_err(xlsx_err)?;
+            } else {
+                warn_py(
+                    py,
+                    &format!("column_widths: invalid width {width} at index {idx}, skipped"),
+                )?;
+            }
+        }
+    } else {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "column_widths must be a dict (by column name) or a list (positional)",
+        ));
+    }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod arrow_ffi;
 mod arrow_writer;
 mod csv_writer;
 mod data_types;
+mod format;
 mod helpers;
 mod utils;
 mod worksheet;
@@ -14,5 +15,6 @@ fn rustpy_xlsxwriter(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(worksheet::write_worksheets, m)?)?;
     m.add_function(wrap_pyfunction!(utils::validate_sheet_name, m)?)?;
     m.add_function(wrap_pyfunction!(csv_writer::write_csv, m)?)?;
+    m.add_class::<format::Format>()?;
     Ok(())
 }

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -16,6 +16,11 @@ pub fn xlsx_err(e: impl std::fmt::Display) -> PyErr {
 
 /// Generic cell writer with full Python type cascade. Returns the
 /// detected column type so callers may cache and fast-path subsequent rows.
+///
+/// `col_override` is an explicit per-column `Format` (from `column_formats`).
+/// When `Some`, it wins over `float_fmt` for numeric cells and over
+/// `datetime_fmt` for datetime cells. When `None`, behaviour is identical
+/// to before (byte-for-byte compatible with no-override callers).
 fn write_py_any(
     worksheet: &mut rust_xlsxwriter::Worksheet,
     row: u32,
@@ -24,6 +29,7 @@ fn write_py_any(
     float_fmt: Option<&Format>,
     datetime_fmt: Option<&Format>,
     datetime_cols_set: &mut HashSet<u16>,
+    col_override: Option<&Format>,
 ) -> PyResult<ColType> {
     if value.is_none() {
         worksheet.write_string(row, col, "").map_err(xlsx_err)?;
@@ -38,7 +44,8 @@ fn write_py_any(
     }
 
     if let Ok(f) = value.cast::<pyo3::types::PyFloat>() {
-        write_num(worksheet, row, col, f.value(), float_fmt)?;
+        let num_fmt = col_override.or(float_fmt);
+        write_num(worksheet, row, col, f.value(), num_fmt)?;
         return Ok(ColType::Float);
     }
 
@@ -52,12 +59,19 @@ fn write_py_any(
 
     if let Ok(i) = value.cast::<pyo3::types::PyInt>() {
         let val: f64 = i.extract()?;
-        worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+        if let Some(fmt) = col_override {
+            worksheet
+                .write_number_with_format(row, col, val, fmt)
+                .map_err(xlsx_err)?;
+        } else {
+            worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+        }
         return Ok(ColType::Int);
     }
 
     if let Ok(dt) = value.cast::<PyDateTime>() {
-        if let Some(fmt) = datetime_fmt {
+        let eff_dt_fmt = col_override.or(datetime_fmt);
+        if let Some(fmt) = eff_dt_fmt {
             if datetime_cols_set.insert(col) {
                 worksheet.set_column_format(col, fmt).map_err(xlsx_err)?;
             }
@@ -71,7 +85,8 @@ fn write_py_any(
 
     // Date AFTER DateTime (datetime is a subclass of date)
     if let Ok(d) = value.cast::<PyDate>() {
-        if let Some(fmt) = datetime_fmt {
+        let eff_dt_fmt = col_override.or(datetime_fmt);
+        if let Some(fmt) = eff_dt_fmt {
             if datetime_cols_set.insert(col) {
                 worksheet.set_column_format(col, fmt).map_err(xlsx_err)?;
             }
@@ -90,7 +105,8 @@ fn write_py_any(
     }
 
     if let Ok(val) = value.extract::<f64>() {
-        write_num(worksheet, row, col, val, float_fmt)?;
+        let num_fmt = col_override.or(float_fmt);
+        write_num(worksheet, row, col, val, num_fmt)?;
         return Ok(ColType::Float);
     }
 
@@ -103,6 +119,12 @@ fn write_py_any(
 /// Fast-path dispatch using a cached `ColType`. Returns `true` if the
 /// value matched the cached type and was written; `false` to fall back
 /// to [`write_py_any`].
+///
+/// `col_override` is an explicit per-column `Format` (from `column_formats`).
+/// When `Some`, it wins over `float_fmt` for numeric cells and over
+/// `datetime_fmt` for datetime cells. When `None`, behaviour is identical
+/// to before (byte-for-byte compatible with no-override callers).
+#[allow(clippy::too_many_arguments)]
 fn try_cached_write(
     worksheet: &mut rust_xlsxwriter::Worksheet,
     row: u32,
@@ -112,6 +134,7 @@ fn try_cached_write(
     float_fmt: Option<&Format>,
     datetime_fmt: &Format,
     datetime_cols_set: &mut HashSet<u16>,
+    col_override: Option<&Format>,
 ) -> PyResult<bool> {
     match cached {
         ColType::String => {
@@ -124,7 +147,8 @@ fn try_cached_write(
         }
         ColType::Float => {
             if let Ok(f) = value.cast::<pyo3::types::PyFloat>() {
-                write_num(worksheet, row, col, f.value(), float_fmt)?;
+                let num_fmt = col_override.or(float_fmt);
+                write_num(worksheet, row, col, f.value(), num_fmt)?;
                 return Ok(true);
             }
         }
@@ -139,15 +163,22 @@ fn try_cached_write(
         ColType::Int => {
             if let Ok(i) = value.cast::<pyo3::types::PyInt>() {
                 let val: f64 = i.extract()?;
-                worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+                if let Some(fmt) = col_override {
+                    worksheet
+                        .write_number_with_format(row, col, val, fmt)
+                        .map_err(xlsx_err)?;
+                } else {
+                    worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+                }
                 return Ok(true);
             }
         }
         ColType::DateTime => {
             if let Ok(dt) = value.cast::<PyDateTime>() {
+                let eff_dt_fmt = col_override.unwrap_or(datetime_fmt);
                 if datetime_cols_set.insert(col) {
                     worksheet
-                        .set_column_format(col, datetime_fmt)
+                        .set_column_format(col, eff_dt_fmt)
                         .map_err(xlsx_err)?;
                 }
                 let excel_dt = py_datetime_to_excel(&dt)?;
@@ -159,9 +190,10 @@ fn try_cached_write(
         }
         ColType::Date => {
             if let Ok(d) = value.cast::<PyDate>() {
+                let eff_dt_fmt = col_override.unwrap_or(datetime_fmt);
                 if datetime_cols_set.insert(col) {
                     worksheet
-                        .set_column_format(col, datetime_fmt)
+                        .set_column_format(col, eff_dt_fmt)
                         .map_err(xlsx_err)?;
                 }
                 let excel_dt = py_date_to_excel(&d)?;
@@ -205,6 +237,7 @@ fn polars_kind(dtype_str: &str) -> PolarsKind {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_worksheet_content(
     worksheet: &mut rust_xlsxwriter::Worksheet,
     records: &WorksheetData,
@@ -216,6 +249,10 @@ fn write_worksheet_content(
     index_columns: Option<&Vec<String>>,
     autofit: bool,
     bold_headers: bool,
+    column_width: Option<f64>,
+    column_widths: Option<&Bound<'_, PyAny>>,
+    column_formats: Option<&Bound<'_, PyAny>>,
+    header_format: Option<&crate::format::Format>,
     py: Python,
 ) -> PyResult<()> {
     let float_fmt = float_format.map(|s| Format::new().set_num_format(s));
@@ -225,6 +262,7 @@ fn write_worksheet_content(
     let datetime_fmt = Format::new().set_num_format(dt_fmt_str);
     let bold_fmt = Format::new().set_bold();
     let mut datetime_cols_set: HashSet<u16> = HashSet::new();
+    let mut final_headers: Vec<String> = Vec::new();
 
     match records {
         WorksheetData::ArrowDataFrame(stream_obj) => {
@@ -232,6 +270,11 @@ fn write_worksheet_content(
                 let reader = crate::arrow_ffi::stream_to_reader(stream_obj, py)?;
 
                 let schema = reader.schema();
+                final_headers = schema
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().to_string())
+                    .collect();
                 for (col, field) in schema.fields().iter().enumerate() {
                     write_header(
                         worksheet,
@@ -240,11 +283,18 @@ fn write_worksheet_content(
                         bold_headers,
                         &bold_fmt,
                         index_columns,
+                        header_format.map(|h| &h.inner),
                     )?;
                 }
 
                 let mut current_row: u32 = 1;
                 let mut formats_set = false;
+
+                // Resolve per-column formats ONCE (after headers are known).
+                // Apply set_column_format BEFORE the first batch — constant memory mode requires
+                // column formats to be set before their data rows.
+                let col_formats: Vec<Option<crate::format::Format>> =
+                    crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
 
                 for batch_result in reader {
                     let batch = batch_result.map_err(|e| {
@@ -255,11 +305,14 @@ fn write_worksheet_content(
                     })?;
 
                     if !formats_set {
+                        // Auto datetime column formats first…
                         crate::arrow_writer::set_datetime_column_formats(
                             worksheet,
                             &batch,
                             &datetime_fmt,
                         )?;
+                        // …then explicit column_formats override them (and any other cols).
+                        crate::format::apply_column_formats(worksheet, &col_formats)?;
                         formats_set = true;
                     }
 
@@ -268,6 +321,7 @@ fn write_worksheet_content(
                         &batch,
                         current_row,
                         float_fmt.as_ref(),
+                        &col_formats,
                     )?;
 
                     current_row += batch.num_rows() as u32;
@@ -279,8 +333,8 @@ fn write_worksheet_content(
             // least write the header row from `.columns`.
             if arrow_ok.is_err() {
                 if let Ok(cols) = stream_obj.getattr(py, "columns") {
-                    let headers: Vec<String> = cols.extract(py).unwrap_or_default();
-                    for (col, header) in headers.iter().enumerate() {
+                    final_headers = cols.extract(py).unwrap_or_default();
+                    for (col, header) in final_headers.iter().enumerate() {
                         write_header(
                             worksheet,
                             col as u16,
@@ -288,6 +342,7 @@ fn write_worksheet_content(
                             bold_headers,
                             &bold_fmt,
                             index_columns,
+                            header_format.map(|h| &h.inner),
                         )?;
                     }
                 }
@@ -299,6 +354,9 @@ fn write_worksheet_content(
                 let mut headers: Vec<String> = Vec::new();
                 let mut headers_written = false;
                 let mut col_types: Vec<ColType> = Vec::new();
+                // Resolved once when headers are first seen; kept alive for the
+                // entire row loop so we can hand out &Format borrows per cell.
+                let mut col_formats: Vec<Option<crate::format::Format>> = Vec::new();
 
                 for (row_idx, row_res) in rows.enumerate() {
                     let row_obj = row_res?;
@@ -320,9 +378,16 @@ fn write_worksheet_content(
                                 bold_headers,
                                 &bold_fmt,
                                 index_columns,
+                                header_format.map(|h| &h.inner),
                             )?;
                         }
                         col_types.resize(headers.len(), ColType::Unknown);
+                        final_headers = headers.clone();
+                        // Resolve per-column formats ONCE and keep them for the whole loop.
+                        // Apply set_column_format BEFORE writing data rows (constant memory mode).
+                        col_formats =
+                            crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
+                        crate::format::apply_column_formats(worksheet, &col_formats)?;
                         headers_written = true;
                     }
 
@@ -334,6 +399,10 @@ fn write_worksheet_content(
                             .copied()
                             .unwrap_or(ColType::Unknown);
 
+                        // Column format override: wins over float_fmt / datetime_fmt.
+                        let col_override: Option<&rust_xlsxwriter::Format> =
+                            col_formats.get(col).and_then(|o| o.as_ref()).map(|f| &f.inner);
+
                         let written = try_cached_write(
                             worksheet,
                             row_u32,
@@ -343,6 +412,7 @@ fn write_worksheet_content(
                             float_fmt.as_ref(),
                             &datetime_fmt,
                             &mut datetime_cols_set,
+                            col_override,
                         )?;
 
                         if !written {
@@ -354,6 +424,7 @@ fn write_worksheet_content(
                                 float_fmt.as_ref(),
                                 Some(&datetime_fmt),
                                 &mut datetime_cols_set,
+                                col_override,
                             )?;
                             if col < col_types.len() && col_types[col] == ColType::Unknown {
                                 col_types[col] = detected;
@@ -367,6 +438,7 @@ fn write_worksheet_content(
         WorksheetData::PandasDataFrame(df) => {
             let columns = df.getattr(py, "columns")?;
             let headers: Vec<String> = columns.extract(py)?;
+            final_headers = headers.clone();
             let dtypes = df.getattr(py, "dtypes")?;
             let dtypes_list: Vec<Bound<'_, PyAny>> =
                 dtypes.bind(py).try_iter()?.collect::<Result<Vec<_>, _>>()?;
@@ -379,6 +451,7 @@ fn write_worksheet_content(
                     bold_headers,
                     &bold_fmt,
                     index_columns,
+                    header_format.map(|h| &h.inner),
                 )?;
             }
 
@@ -395,6 +468,8 @@ fn write_worksheet_content(
 
             let nrows: usize = df.call_method0(py, "__len__")?.extract(py)?;
 
+            // Auto datetime column formats first, then explicit column_formats
+            // override (constant memory: BEFORE writing data rows).
             for (col_idx, kind) in col_kinds.iter().enumerate() {
                 if *kind == 'M' && datetime_cols_set.insert(col_idx as u16) {
                     worksheet
@@ -402,6 +477,9 @@ fn write_worksheet_content(
                         .map_err(xlsx_err)?;
                 }
             }
+            let col_formats: Vec<Option<crate::format::Format>> =
+                crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
+            crate::format::apply_column_formats(worksheet, &col_formats)?;
 
             write_df_rows(
                 worksheet,
@@ -412,11 +490,13 @@ fn write_worksheet_content(
                 float_fmt.as_ref(),
                 &datetime_fmt,
                 &mut datetime_cols_set,
+                &col_formats,
             )?;
         }
 
         WorksheetData::PolarsDataFrame(df) => {
             let columns: Vec<String> = df.getattr(py, "columns")?.extract(py)?;
+            final_headers = columns.clone();
             let dtypes = df.getattr(py, "dtypes")?;
             let dtypes_list: Vec<Bound<'_, PyAny>> =
                 dtypes.bind(py).try_iter()?.collect::<Result<Vec<_>, _>>()?;
@@ -429,6 +509,7 @@ fn write_worksheet_content(
                     bold_headers,
                     &bold_fmt,
                     index_columns,
+                    header_format.map(|h| &h.inner),
                 )?;
             }
 
@@ -443,6 +524,8 @@ fn write_worksheet_content(
 
             let nrows: usize = df.call_method0(py, "__len__")?.extract(py)?;
 
+            // Auto datetime column formats first, then explicit column_formats
+            // override (constant memory: BEFORE writing data rows).
             for (col_idx, kind) in col_kinds.iter().enumerate() {
                 if *kind == PolarsKind::Temporal
                     && datetime_cols_set.insert(col_idx as u16)
@@ -452,6 +535,9 @@ fn write_worksheet_content(
                         .map_err(xlsx_err)?;
                 }
             }
+            let col_formats: Vec<Option<crate::format::Format>> =
+                crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
+            crate::format::apply_column_formats(worksheet, &col_formats)?;
 
             write_df_rows(
                 worksheet,
@@ -462,6 +548,7 @@ fn write_worksheet_content(
                 float_fmt.as_ref(),
                 &datetime_fmt,
                 &mut datetime_cols_set,
+                &col_formats,
             )?;
         }
     }
@@ -475,6 +562,14 @@ fn write_worksheet_content(
     if autofit {
         worksheet.autofit();
     }
+    crate::helpers::apply_column_widths(
+        worksheet,
+        &final_headers,
+        column_width,
+        column_widths,
+        py,
+    )?;
+
     if let Some(password) = password {
         worksheet.protect_with_password(password);
     }
@@ -512,6 +607,11 @@ impl<'py> ColAccess<'py> {
 /// Shared row writer for Pandas and Polars paths. Both frameworks provide
 /// per-column Python lists plus a per-column kind — the row-level dispatch
 /// is identical, so a single helper handles both.
+///
+/// `col_formats` is a per-column slice of optional `Format`s resolved from
+/// `column_formats`. When `Some`, the column format wins over `float_fmt` for
+/// numeric/float columns, and is applied to string columns as well. Pass an
+/// empty slice when no overrides are needed (byte-identical behaviour).
 #[allow(clippy::too_many_arguments)]
 fn write_df_rows<F>(
     worksheet: &mut rust_xlsxwriter::Worksheet,
@@ -522,6 +622,7 @@ fn write_df_rows<F>(
     float_fmt: Option<&Format>,
     datetime_fmt: &Format,
     datetime_cols_set: &mut HashSet<u16>,
+    col_formats: &[Option<crate::format::Format>],
 ) -> PyResult<()>
 where
     F: Fn(usize) -> PolarsKind,
@@ -543,6 +644,10 @@ where
             let col_u16 = col_idx as u16;
             let item = col_list.get(row)?;
 
+            // Per-column format override: wins over float_fmt for numeric cols.
+            let col_override: Option<&Format> =
+                col_formats.get(col_idx).and_then(|o| o.as_ref()).map(|f| &f.inner);
+
             if item.is_none() {
                 worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
                 continue;
@@ -551,13 +656,19 @@ where
             match kind_at(col_idx) {
                 PolarsKind::Int => {
                     let val: f64 = item.extract()?;
-                    worksheet
-                        .write_number(row_u32, col_u16, val)
-                        .map_err(xlsx_err)?;
+                    if let Some(fmt) = col_override {
+                        worksheet
+                            .write_number_with_format(row_u32, col_u16, val, fmt)
+                            .map_err(xlsx_err)?;
+                    } else {
+                        worksheet
+                            .write_number(row_u32, col_u16, val)
+                            .map_err(xlsx_err)?;
+                    }
                 }
                 PolarsKind::Float => {
                     let val: f64 = item.extract()?;
-                    write_num(worksheet, row_u32, col_u16, val, float_fmt)?;
+                    write_num(worksheet, row_u32, col_u16, val, col_override.or(float_fmt))?;
                 }
                 PolarsKind::Bool => {
                     let val: bool = item.extract()?;
@@ -591,6 +702,7 @@ where
                         float_fmt,
                         Some(datetime_fmt),
                         datetime_cols_set,
+                        col_override,
                     )?;
                 }
             }
@@ -599,8 +711,22 @@ where
     Ok(())
 }
 
+/// Resolve a per-sheet value from a dict keyed by sheet name, falling back
+/// to the `"general"` key. Returns the matching Python value, if any.
+fn keyed_get<'py>(
+    dict: Option<&Bound<'py, pyo3::types::PyDict>>,
+    sheet: &str,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    let Some(dict) = dict else { return Ok(None) };
+    if let Some(v) = dict.get_item(sheet)? {
+        return Ok(Some(v));
+    }
+    dict.get_item("general")
+}
+
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false))]
+#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None))]
 pub fn write_worksheets(
     py: Python,
     records_with_sheet_name: Vec<(String, WorksheetData)>,
@@ -612,6 +738,10 @@ pub fn write_worksheets(
     index_columns: Option<Vec<String>>,
     autofit: bool,
     bold_headers: bool,
+    column_width: Option<Bound<'_, pyo3::types::PyDict>>,
+    column_widths: Option<Bound<'_, pyo3::types::PyDict>>,
+    column_formats: Option<Bound<'_, pyo3::types::PyDict>>,
+    header_format: Option<Bound<'_, pyo3::types::PyDict>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     for (sheet_name, records) in records_with_sheet_name {
@@ -625,6 +755,22 @@ pub fn write_worksheets(
             .map(|c| c.resolve(&sheet_name))
             .unwrap_or_default();
 
+        let sheet_uniform: Option<f64> =
+            match keyed_get(column_width.as_ref(), &sheet_name)? {
+                Some(v) => Some(v.extract()?),
+                None => None,
+            };
+        let sheet_spec: Option<Bound<'_, PyAny>> =
+            keyed_get(column_widths.as_ref(), &sheet_name)?;
+
+        let sheet_col_fmts: Option<Bound<'_, PyAny>> =
+            keyed_get(column_formats.as_ref(), &sheet_name)?;
+        let sheet_hdr_fmt: Option<crate::format::Format> =
+            match keyed_get(header_format.as_ref(), &sheet_name)? {
+                Some(v) => Some(v.extract()?),
+                None => None,
+            };
+
         write_worksheet_content(
             &mut worksheet,
             &records,
@@ -636,6 +782,10 @@ pub fn write_worksheets(
             index_columns.as_ref(),
             autofit,
             bold_headers,
+            sheet_uniform,
+            sheet_spec.as_ref(),
+            sheet_col_fmts.as_ref(),
+            sheet_hdr_fmt.as_ref(),
             py,
         )?;
     }
@@ -644,8 +794,9 @@ pub fn write_worksheets(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false))]
+#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None))]
 pub fn write_worksheet(
     py: Python,
     records: WorksheetData,
@@ -659,6 +810,10 @@ pub fn write_worksheet(
     index_columns: Option<Vec<String>>,
     autofit: bool,
     bold_headers: bool,
+    column_width: Option<f64>,
+    column_widths: Option<Bound<'_, PyAny>>,
+    column_formats: Option<Bound<'_, PyAny>>,
+    header_format: Option<Bound<'_, crate::format::Format>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     let mut worksheet = workbook.add_worksheet_with_constant_memory();
@@ -667,6 +822,9 @@ pub fn write_worksheet(
         ensure_valid_sheet_name(&sheet_name)?;
         worksheet.set_name(sheet_name).map_err(xlsx_err)?;
     }
+
+    let hdr_borrow = header_format.as_ref().map(|h| h.borrow());
+    let hdr_ref = hdr_borrow.as_deref();
 
     write_worksheet_content(
         &mut worksheet,
@@ -679,6 +837,10 @@ pub fn write_worksheet(
         index_columns.as_ref(),
         autofit,
         bold_headers,
+        column_width,
+        column_widths.as_ref(),
+        column_formats.as_ref(),
+        hdr_ref,
         py,
     )?;
 

--- a/tests/test_column_widths.py
+++ b/tests/test_column_widths.py
@@ -1,0 +1,204 @@
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import write_worksheet, write_worksheets, FastExcel
+
+RECORDS = [
+    {"row": 1, "var": "age", "label": "Age in years"},
+    {"row": 2, "var": "name", "label": "Full legal name"},
+]
+
+
+def widths(path, sheet=None):
+    """{column_letter: width} for a sheet (active if sheet=None), expanding
+    range-based <col min max> entries that set_column_range_width emits."""
+    wb = openpyxl.load_workbook(str(path))
+    ws = wb[sheet] if sheet else wb.active
+    out = {}
+    for dim in ws.column_dimensions.values():
+        if not dim.width:
+            continue
+        for ci in range(dim.min or 1, (dim.max or dim.min or 1) + 1):
+            out[openpyxl.utils.get_column_letter(ci)] = dim.width
+    wb.close()
+    return out
+
+
+def approx_width(expected):
+    """
+    openpyxl reads back Excel column widths with a +0.7109375 rounding offset
+    introduced by rust_xlsxwriter's pixel-to-character-unit conversion.  We
+    accept anything within ±1 character unit of the requested value so the
+    tests remain stable across Excel rendering engines.
+    """
+    return pytest.approx(expected, abs=0.75)
+
+
+class TestSingleSheetWidthsFunctional:
+    def test_uniform_width(self, tmp_path):
+        p = tmp_path / "uniform.xlsx"
+        write_worksheet(RECORDS, p, column_width=15, autofit=False)
+        w = widths(p)
+        assert w["A"] == approx_width(15)
+        assert w["B"] == approx_width(15)
+        assert w["C"] == approx_width(15)
+
+    def test_dict_by_name(self, tmp_path):
+        p = tmp_path / "dict.xlsx"
+        write_worksheet(RECORDS, p, column_widths={"row": 7, "var": 22, "label": 40}, autofit=False)
+        w = widths(p)
+        assert w["A"] == approx_width(7)
+        assert w["B"] == approx_width(22)
+        assert w["C"] == approx_width(40)
+
+    def test_list_positional(self, tmp_path):
+        p = tmp_path / "list.xlsx"
+        write_worksheet(RECORDS, p, column_widths=[7, 22, 40], autofit=False)
+        w = widths(p)
+        assert w["A"] == approx_width(7)
+        assert w["B"] == approx_width(22)
+        assert w["C"] == approx_width(40)
+
+    def test_uniform_plus_override(self, tmp_path):
+        p = tmp_path / "both.xlsx"
+        write_worksheet(RECORDS, p, column_width=10, column_widths={"label": 40}, autofit=False)
+        w = widths(p)
+        assert w["A"] == approx_width(10)
+        assert w["B"] == approx_width(10)
+        assert w["C"] == approx_width(40)
+        # Verify override actually changed C differently from A/B
+        assert w["C"] > w["A"] + 20
+
+    def test_explicit_beats_autofit(self, tmp_path):
+        p = tmp_path / "vs_autofit.xlsx"
+        write_worksheet(RECORDS, p, column_widths={"label": 50}, autofit=True)
+        assert widths(p)["C"] == approx_width(50)
+
+
+class TestMultiSheetWidths:
+    def test_functional_keyed(self, tmp_path):
+        p = tmp_path / "multi.xlsx"
+        write_worksheets(
+            [("Raw", RECORDS), ("Meta", RECORDS)],
+            p,
+            autofit=False,
+            column_width={"general": 12, "Meta": 8},
+            column_widths={"Meta": {"label": 40}},
+        )
+        raw = widths(p, "Raw")
+        meta = widths(p, "Meta")
+        assert raw["A"] == approx_width(12)
+        assert raw["C"] == approx_width(12)
+        assert meta["A"] == approx_width(8)
+        assert meta["B"] == approx_width(8)
+        assert meta["C"] == approx_width(40)
+
+
+class TestSingleSheetWidthsBuilder:
+    def test_uniform_width(self, tmp_path):
+        p = tmp_path / "b_uniform.xlsx"
+        FastExcel(p, autofit=False).sheet("S", RECORDS, column_width=15).save()
+        w = widths(p)
+        assert w["A"] == approx_width(15)
+        assert w["C"] == approx_width(15)
+
+    def test_dict_by_name(self, tmp_path):
+        p = tmp_path / "b_dict.xlsx"
+        FastExcel(p, autofit=False).sheet(
+            "S", RECORDS, column_widths={"row": 7, "var": 22, "label": 40}
+        ).save()
+        w = widths(p)
+        assert w["A"] == approx_width(7)
+        assert w["B"] == approx_width(22)
+        assert w["C"] == approx_width(40)
+
+    def test_list_positional(self, tmp_path):
+        p = tmp_path / "b_list.xlsx"
+        FastExcel(p, autofit=False).sheet("S", RECORDS, column_widths=[7, 22, 40]).save()
+        w = widths(p)
+        assert w["A"] == approx_width(7)
+        assert w["C"] == approx_width(40)
+
+    def test_uniform_plus_override(self, tmp_path):
+        p = tmp_path / "b_both.xlsx"
+        FastExcel(p, autofit=False).sheet(
+            "S", RECORDS, column_width=10, column_widths={"label": 40}
+        ).save()
+        w = widths(p)
+        assert w["A"] == approx_width(10)
+        assert w["C"] == approx_width(40)
+
+
+class TestMultiSheetWidthsBuilder:
+    def test_builder_per_sheet(self, tmp_path):
+        p = tmp_path / "builder_multi.xlsx"
+        (
+            FastExcel(p, autofit=False)
+            .sheet("Raw", RECORDS, column_width=12)
+            .sheet("Meta", RECORDS, column_widths=[8, 8, 40])
+            .save()
+        )
+        raw = widths(p, "Raw")
+        meta = widths(p, "Meta")
+        assert raw["A"] == approx_width(12)
+        assert raw["C"] == approx_width(12)
+        assert meta["A"] == approx_width(8)
+        assert meta["B"] == approx_width(8)
+        assert meta["C"] == approx_width(40)
+
+
+class TestWidthWarningsAndIndex:
+    def test_unknown_name_warns(self, tmp_path):
+        p = tmp_path / "unknown.xlsx"
+        with pytest.warns(UserWarning, match="unknown column 'nope'"):
+            FastExcel(p, autofit=False).sheet(
+                "S", RECORDS, column_widths={"row": 7, "nope": 9}
+            ).save()
+        assert widths(p)["A"] == approx_width(7)  # valid column still applied
+
+    def test_list_too_long_warns(self, tmp_path):
+        p = tmp_path / "toolong.xlsx"
+        with pytest.warns(UserWarning, match=r"index 3 out of range"):
+            FastExcel(p, autofit=False).sheet(
+                "S", RECORDS, column_widths=[7, 22, 40, 99]
+            ).save()
+        assert widths(p)["C"] == approx_width(40)
+
+    def test_invalid_width_warns(self, tmp_path):
+        p = tmp_path / "invalid.xlsx"
+        with pytest.warns(UserWarning, match=r"invalid width -5"):
+            FastExcel(p, autofit=False).sheet(
+                "S", RECORDS, column_widths={"row": -5}
+            ).save()
+        # Negative width skipped → column "A" has no explicit width applied.
+        assert "A" not in widths(p)
+
+    def test_index_columns_alignment(self, tmp_path):
+        """index_columns only styles columns; it does not shift positions,
+        so width indices still map to data column order."""
+        p = tmp_path / "indexed.xlsx"
+        write_worksheet(
+            RECORDS, p, index_columns=["row"], column_widths={"label": 40},
+            autofit=False,
+        )
+        assert widths(p)["C"] == approx_width(40)
+
+    def test_unsupported_spec_type_raises(self, tmp_path):
+        p = tmp_path / "badtype.xlsx"
+        with pytest.raises(ValueError, match="must be a dict .* or a list"):
+            FastExcel(p, autofit=False).sheet("S", RECORDS, column_widths=42).save()
+
+    def test_sheet_absent_from_both_dicts(self, tmp_path):
+        """A sheet with no sheet-specific and no 'general' width entry gets
+        no explicit widths (autofit/default)."""
+        p = tmp_path / "absent.xlsx"
+        write_worksheets(
+            [("Has", RECORDS), ("None", RECORDS)],
+            p,
+            autofit=False,
+            column_width={"Has": 15},
+        )
+        has = widths(p, "Has")
+        none = widths(p, "None")
+        assert has["A"] == approx_width(15)
+        assert none == {}  # no explicit width set for the unmatched sheet

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -123,6 +123,128 @@ class TestCSVGenerator:
         assert len(lines) == 101  # header + 100 rows
 
 
+class TestCSVRecordsTypeCache:
+    """Exercise the Records first-row type cache in csv_writer: the cached
+    column type is set from row 1, hit on stable columns, and must fall back
+    to the full cascade when a later row's value type differs."""
+
+    def test_stable_types_cache_hit(self, tmp_path):
+        path = str(tmp_path / "stable.csv")
+        records = [
+            {"i": 1, "f": 1.5, "s": "a", "b": True},
+            {"i": 2, "f": 2.5, "s": "b", "b": False},
+            {"i": 3, "f": 3.5, "s": "c", "b": True},
+        ]
+        FastExcel(path).sheet("S", records).save()
+
+        lines = open(path).read().strip().split("\n")
+        assert lines[0] == "i,f,s,b"
+        assert lines[1] == "1,1.5,a,true"
+        assert lines[2] == "2,2.5,b,false"
+        assert lines[3] == "3,3.5,c,true"
+
+    def test_type_switch_falls_back(self, tmp_path):
+        """Column ``v``: int in row 1 (caches Int), then string / float /
+        bool in later rows — cache misses must re-run the cascade, not coerce
+        to the cached type."""
+        path = str(tmp_path / "switch.csv")
+        records = [
+            {"v": 1},
+            {"v": "two"},
+            {"v": 3.5},
+            {"v": True},
+        ]
+        FastExcel(path).sheet("S", records).save()
+
+        lines = open(path).read().strip().split("\n")
+        assert lines[0] == "v"
+        assert lines[1] == "1"
+        assert lines[2] == "two"
+        assert lines[3] == "3.5"
+        assert lines[4] == "true"
+
+    def test_none_in_first_row_then_typed(self, tmp_path):
+        """A ``None`` in row 1 leaves the column type Unknown; the first
+        non-null value sets the cache, and escaping still applies on miss."""
+        path = str(tmp_path / "none_first.csv")
+        records = [
+            {"x": None},
+            {"x": "has,comma"},
+            {"x": "plain"},
+        ]
+        FastExcel(path).sheet("S", records).save()
+
+        lines = open(path).read().strip().split("\n")
+        assert lines[0] == "x"
+        assert lines[1] == ""
+        assert lines[2] == '"has,comma"'
+        assert lines[3] == "plain"
+
+
+class TestCSVArrowPath:
+    """Verify DataFrame → CSV goes through the Arrow C Data Interface
+    and produces the expected output for mixed types + nulls."""
+
+    def test_pandas_arrow_types(self, tmp_path):
+        path = str(tmp_path / "arrow.csv")
+        df = pd.DataFrame(
+            {
+                "i": [1, 2, 3],
+                "f": [1.5, 2.5, 3.5],
+                "s": ["a", "b", "c"],
+                "b": [True, False, True],
+                "ts": pd.to_datetime(
+                    ["2024-01-02 03:04:05", "2025-06-07 08:09:10", pd.NaT]
+                ),
+            }
+        )
+        write_csv(df, path)
+
+        lines = open(path).read().strip().split("\n")
+        assert lines[0] == "i,f,s,b,ts"
+        assert lines[1] == "1,1.5,a,true,2024-01-02T03:04:05"
+        assert lines[2] == "2,2.5,b,false,2025-06-07T08:09:10"
+        # Null datetime → empty cell
+        assert lines[3].split(",")[4] == ""
+
+    def test_polars_arrow_types(self, tmp_path):
+        path = str(tmp_path / "arrow_pl.csv")
+        df = pl.DataFrame(
+            {
+                "i": [10, 20, 30],
+                "s": ["x", "y", None],
+                "b": [True, None, False],
+            }
+        )
+        write_csv(df, path)
+
+        lines = open(path).read().strip().split("\n")
+        assert lines[0] == "i,s,b"
+        assert lines[1] == "10,x,true"
+        # Row 1: b is None → trailing empty
+        assert lines[2] == "20,y,"
+        # Row 2: s is None → middle empty
+        assert lines[3] == "30,,false"
+
+    def test_pandas_escape_in_arrow_path(self, tmp_path):
+        path = str(tmp_path / "arrow_esc.csv")
+        df = pd.DataFrame({"A": ['has,comma', 'has"quote']})
+        write_csv(df, path)
+
+        content = open(path).read()
+        assert '"has,comma"' in content
+        assert '"has""quote"' in content
+
+    def test_pathlib_path_target(self, tmp_path):
+        """write_csv accepts a pathlib.Path, not only str."""
+        from pathlib import Path
+
+        p = Path(tmp_path) / "pathlib.csv"
+        df = pd.DataFrame({"A": [1, 2]})
+        write_csv(df, p)
+        assert p.read_text().startswith("A\n")
+
+
 class TestWriteCSVFunction:
     def test_direct_call(self, tmp_path):
         path = str(tmp_path / "out.csv")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,265 @@
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import Format, write_worksheet
+
+RECORDS = [{"name": "Alice", "score": 90}, {"name": "Bob", "score": 80}]
+
+
+def load(path):
+    return openpyxl.load_workbook(str(path)).active
+
+
+class TestColumnFormatsRecords:
+    def test_bold_by_name(self, tmp_path):
+        p = tmp_path / "bold.xlsx"
+        write_worksheet(
+            RECORDS, p, column_formats={"name": Format().set_bold()}, autofit=False
+        )
+        ws = load(p)
+        assert ws["A2"].font.bold is True
+        assert ws["B2"].font.bold in (False, None)
+
+    def test_bg_color_by_list(self, tmp_path):
+        p = tmp_path / "bg.xlsx"
+        write_worksheet(
+            RECORDS, p,
+            column_formats=[Format().set_background_color("#FFFF00"), None],
+            autofit=False,
+        )
+        ws = load(p)
+        assert ws["A2"].fill.fgColor.rgb.endswith("FFFF00")
+
+    def test_named_color(self, tmp_path):
+        p = tmp_path / "named.xlsx"
+        write_worksheet(
+            RECORDS, p, column_formats={"name": Format().set_font_color("red")},
+            autofit=False,
+        )
+        ws = load(p)
+        assert ws["A2"].font.color.rgb.endswith("FF0000")
+
+    def test_chaining(self, tmp_path):
+        # Chaining must return a Format usable downstream.
+        p = tmp_path / "chain.xlsx"
+        f = Format().set_bold().set_font_color("red").set_align("center")
+        write_worksheet(RECORDS, p, column_formats={"name": f}, autofit=False)
+        ws = load(p)
+        assert ws["A2"].font.bold is True
+
+
+class TestHeaderFormat:
+    def test_header_format_applied(self, tmp_path):
+        p = tmp_path / "hdr.xlsx"
+        write_worksheet(
+            RECORDS, p, header_format=Format().set_bold().set_font_color("#0000FF"),
+            autofit=False,
+        )
+        ws = load(p)
+        assert ws["A1"].font.bold is True
+        assert ws["A1"].font.color.rgb.endswith("0000FF")
+        assert ws["B1"].font.bold is True
+
+    def test_header_format_beats_bold_headers(self, tmp_path):
+        p = tmp_path / "hdr2.xlsx"
+        write_worksheet(
+            RECORDS, p, bold_headers=True,
+            header_format=Format().set_italic(),
+            autofit=False,
+        )
+        ws = load(p)
+        assert ws["A1"].font.italic is True
+
+
+class TestNumericPrecedence:
+    def test_column_num_format_beats_float_format(self, tmp_path):
+        p = tmp_path / "num.xlsx"
+        rows = [{"a": 1.5}, {"a": 2.5}]
+        write_worksheet(
+            rows, p, float_format="0.000",
+            column_formats={"a": Format().set_num_format("0.00%")},
+            autofit=False,
+        )
+        ws = load(p)
+        assert ws["A2"].number_format == "0.00%"
+
+    def test_no_override_keeps_float_format(self, tmp_path):
+        p = tmp_path / "num2.xlsx"
+        rows = [{"a": 1.5}]
+        write_worksheet(rows, p, float_format="0.000", autofit=False)
+        ws = load(p)
+        assert ws["A2"].number_format == "0.000"
+
+
+class TestDataFrameFormats:
+    def test_pandas_column_format(self, tmp_path):
+        pd = pytest.importorskip("pandas")
+        p = tmp_path / "pd.xlsx"
+        df = pd.DataFrame({"x": [1.0, 2.0], "y": ["a", "b"]})
+        write_worksheet(
+            df, p,
+            column_formats={"x": Format().set_num_format("0.00%"),
+                            "y": Format().set_bold()},
+            header_format=Format().set_bold(),
+            autofit=False,
+        )
+        ws = load(p)
+        assert ws["A2"].number_format == "0.00%"
+        assert ws["B2"].font.bold is True
+        assert ws["A1"].font.bold is True
+
+    def test_polars_column_format(self, tmp_path):
+        pl = pytest.importorskip("polars")
+        p = tmp_path / "pl.xlsx"
+        df = pl.DataFrame({"x": [1.0, 2.0], "y": ["a", "b"]})
+        write_worksheet(
+            df, p, column_formats=[Format().set_num_format("0.00%"), Format().set_bold()],
+            autofit=False,
+        )
+        ws = load(p)
+        assert ws["A2"].number_format == "0.00%"
+        assert ws["B2"].value == "a"
+        assert ws["B2"].font.bold is True
+
+
+class TestAllSetters:
+    def test_font_attrs(self, tmp_path):
+        p = tmp_path / "font.xlsx"
+        f = (Format().set_font_name("Arial").set_font_size(14)
+             .set_italic().set_font_strikethrough().set_underline("single"))
+        write_worksheet(RECORDS, p, column_formats={"name": f}, autofit=False)
+        c = load(p)["A2"]
+        assert c.font.name == "Arial"
+        assert c.font.sz == 14
+        assert c.font.italic is True
+        assert c.font.strike is True
+        assert c.font.underline == "single"
+
+    def test_border_sides(self, tmp_path):
+        p = tmp_path / "border.xlsx"
+        f = (Format().set_border("thin").set_border_top("double")
+             .set_border_color("#FF0000"))
+        write_worksheet(RECORDS, p, column_formats={"name": f}, autofit=False)
+        c = load(p)["A2"]
+        assert c.border.top.style == "double"
+        assert c.border.left.style == "thin"
+
+    def test_alignment_wrap(self, tmp_path):
+        p = tmp_path / "align.xlsx"
+        f = Format().set_align("center").set_align("vcenter").set_text_wrap()
+        write_worksheet(RECORDS, p, column_formats={"name": f}, autofit=False)
+        c = load(p)["A2"]
+        assert c.alignment.horizontal == "center"
+        assert c.alignment.vertical == "center"
+        assert c.alignment.wrap_text is True
+
+    def test_pattern_solid(self, tmp_path):
+        p = tmp_path / "pat.xlsx"
+        f = Format().set_pattern("solid").set_foreground_color("#00FF00")
+        write_worksheet(RECORDS, p, column_formats={"name": f}, autofit=False)
+        c = load(p)["A2"]
+        assert c.fill.patternType == "solid"
+
+    def test_underline_default(self, tmp_path):
+        p = tmp_path / "ul.xlsx"
+        f = Format().set_underline()  # defaults to single
+        write_worksheet(RECORDS, p, column_formats={"name": f}, autofit=False)
+        assert load(p)["A2"].font.underline == "single"
+
+
+class TestMultiSheetFormats:
+    def _ws(self, path, sheet):
+        return openpyxl.load_workbook(str(path))[sheet]
+
+    def test_keyed(self, tmp_path):
+        from rustpy_xlsxwriter import write_worksheets
+        p = tmp_path / "multi.xlsx"
+        write_worksheets(
+            [("Raw", RECORDS), ("Meta", RECORDS)],
+            p, autofit=False,
+            column_formats={"Meta": {"name": Format().set_bold()}},
+            header_format={"general": Format().set_italic()},
+        )
+        raw = self._ws(p, "Raw")
+        meta = self._ws(p, "Meta")
+        assert raw["A1"].font.italic is True     # general header_format applies to all
+        assert meta["A1"].font.italic is True
+        assert meta["A2"].font.bold is True      # Meta-specific column_formats
+        assert raw["A2"].font.bold in (False, None)  # Raw has no column_formats
+
+
+class TestBuilderFormats:
+    def test_builder(self, tmp_path):
+        from rustpy_xlsxwriter import FastExcel
+        p = tmp_path / "b.xlsx"
+        (
+            FastExcel(p, autofit=False)
+            .sheet("S", RECORDS,
+                   column_formats={"name": Format().set_bold()},
+                   header_format=Format().set_italic())
+            .save()
+        )
+        ws = openpyxl.load_workbook(str(p)).active
+        assert ws["A1"].font.italic is True
+        assert ws["A2"].font.bold is True
+
+    def test_builder_multi(self, tmp_path):
+        from rustpy_xlsxwriter import FastExcel
+        p = tmp_path / "bm.xlsx"
+        (
+            FastExcel(p, autofit=False)
+            .sheet("Raw", RECORDS)
+            .sheet("Meta", RECORDS, column_formats=[Format().set_bold(), None])
+            .save()
+        )
+        meta = openpyxl.load_workbook(str(p))["Meta"]
+        assert meta["A2"].font.bold is True
+        raw = openpyxl.load_workbook(str(p))["Raw"]
+        assert raw["A2"].font.bold in (False, None)
+
+
+class TestFormatErrors:
+    def test_invalid_color_raises(self):
+        with pytest.raises(ValueError, match="invalid color"):
+            Format().set_font_color("notacolor")
+
+    def test_invalid_align_raises(self):
+        with pytest.raises(ValueError, match="invalid align"):
+            Format().set_align("sideways")
+
+    def test_invalid_border_raises(self):
+        with pytest.raises(ValueError, match="invalid border"):
+            Format().set_border("zigzag")
+
+    def test_invalid_pattern_raises(self):
+        with pytest.raises(ValueError):
+            Format().set_pattern("plaid")
+
+    def test_invalid_underline_raises(self):
+        with pytest.raises(ValueError):
+            Format().set_underline("wiggly")
+
+    def test_non_format_value_raises(self, tmp_path):
+        p = tmp_path / "bad.xlsx"
+        with pytest.raises(TypeError):
+            write_worksheet(RECORDS, p, column_formats={"name": "bold"}, autofit=False)
+
+    def test_bad_spec_type_raises(self, tmp_path):
+        p = tmp_path / "bad2.xlsx"
+        with pytest.raises(ValueError, match="dict .* or a list"):
+            write_worksheet(RECORDS, p, column_formats=42, autofit=False)
+
+    def test_unknown_column_warns(self, tmp_path):
+        p = tmp_path / "warn.xlsx"
+        with pytest.warns(UserWarning, match="unknown column 'nope'"):
+            write_worksheet(
+                RECORDS, p, column_formats={"nope": Format().set_bold()}, autofit=False
+            )
+
+    def test_reused_format_two_columns(self, tmp_path):
+        p = tmp_path / "reuse.xlsx"
+        f = Format().set_bold()
+        write_worksheet(RECORDS, p, column_formats={"name": f, "score": f}, autofit=False)
+        ws = load(p)
+        assert ws["A2"].font.bold is True
+        assert ws["B2"].font.bold is True

--- a/tests/test_pathlib_target.py
+++ b/tests/test_pathlib_target.py
@@ -1,0 +1,58 @@
+"""os.PathLike (e.g. pathlib.Path) acceptance across every public entry
+point. `_coerce_target` runs os.fspath() on PathLike and passes other
+objects (file paths as str, file-like buffers) through unchanged."""
+
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, write_worksheet, write_worksheets
+
+
+def _read_cell(path, row, col, sheet=None):
+    wb = openpyxl.load_workbook(str(path))
+    ws = wb[sheet] if sheet else wb.active
+    val = ws.cell(row, col).value
+    wb.close()
+    return val
+
+
+class TestPathLikeTarget:
+    def test_fastexcel_path(self, tmp_path):
+        p = Path(tmp_path) / "fe.xlsx"
+        records = [{"Name": "Alice", "Age": 30}]
+        FastExcel(p).sheet("Data", records).save()
+
+        assert p.exists()
+        assert _read_cell(p, 1, 1) == "Name"
+        assert _read_cell(p, 2, 1) == "Alice"
+        assert _read_cell(p, 2, 2) == 30
+
+    def test_write_worksheet_path(self, tmp_path):
+        p = Path(tmp_path) / "ws.xlsx"
+        records = [{"A": 1, "B": "x"}, {"A": 2, "B": "y"}]
+        write_worksheet(records, p, sheet_name="Sheet1")
+
+        assert p.exists()
+        assert _read_cell(p, 1, 1, "Sheet1") == "A"
+        assert _read_cell(p, 2, 1, "Sheet1") == 1
+        assert _read_cell(p, 3, 2, "Sheet1") == "y"
+
+    def test_write_worksheets_path(self, tmp_path):
+        p = Path(tmp_path) / "wss.xlsx"
+        write_worksheets(
+            [("S1", [{"A": 1}]), ("S2", [{"B": 2}])],
+            p,
+        )
+
+        assert p.exists()
+        assert _read_cell(p, 1, 1, "S1") == "A"
+        assert _read_cell(p, 2, 1, "S1") == 1
+        assert _read_cell(p, 2, 1, "S2") == 2
+
+    def test_str_still_works(self, tmp_path):
+        """str path must keep working (pass-through, not coerced)."""
+        p = tmp_path / "str.xlsx"
+        FastExcel(str(p)).sheet("Data", [{"A": 9}]).save()
+        assert _read_cell(p, 2, 1) == 9


### PR DESCRIPTION
Cell-level formatting (#18): a Format pyclass wrapping rust_xlsxwriter::Format with 41 chainable setters (font, fill, border, alignment, number format), hex/named colour parsing, and string-enum parsers. Attach via column_formats (by-name dict or positional list) and header_format on write_worksheet, write_worksheets (keyed by sheet name with a "general" fallback), and FastExcel.sheet(). Applied across the Records, Pandas, Polars and Arrow paths; an explicit column format wins over float_format/datetime_format.

Per-column widths (#17): column_width (uniform) and column_widths (by-name dict or positional list) on the same three entry points, overriding autofit; unknown names and out-of-range indices warn and skip.

IO and internals: accept os.PathLike targets everywhere; CSV Records first-row type cache with a bool-before-int fix; Arrow CSV zero-copy; shared helpers (write_csv_escaped, apply_column_widths, apply_column_formats); __version__ export. Bump to v0.5.0.

## Summary

<!-- Brief description of what this PR does -->

## Changes

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [ ] `pytest tests/ -m "not benchmark"` passes
- [ ] `cargo check` has no warnings
- [ ] Type stubs (`.pyi`) updated if API changed
- [ ] README updated if applicable
