### PR TITLE
refactor: apply /simplify cleanups (dedup writers, hoist per-column w…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "rustpy_xlsxwriter/**"
+      - "src/**"
+      - "README.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # `pip install .` builds the extension through the maturin backend,
+      # so pdoc can import the real module and read its docstrings + .pyi.
+      - name: Build & install package + pdoc
+        run: pip install . pdoc
+
+      - name: Generate API docs
+        run: pdoc -o site rustpy_xlsxwriter
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "rustpy-xlsxwriter"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpy-xlsxwriter"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Rahmad Afandi <rahmadafandiii@gmail.com>"]
 description = "High-performance Excel and CSV file generation powered by Rust (~7-9x faster)"

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -388,7 +388,7 @@ def validate_sheet_name(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def get_version() -> str:
-    """Return the package version string (e.g. ``'0.5.1'``)."""
+    """Return the package version string (e.g. ``'0.5.2'``)."""
     ...
 
 def get_name() -> str:

--- a/src/arrow_writer.rs
+++ b/src/arrow_writer.rs
@@ -5,7 +5,7 @@ use arrow_schema::{DataType, TimeUnit};
 use pyo3::prelude::*;
 use rust_xlsxwriter::{ExcelDateTime, Format, Worksheet};
 
-use crate::helpers::{write_csv_escaped_guarded, write_num};
+use crate::helpers::{write_csv_escaped_guarded, write_num, write_number_opt, write_string_opt};
 use crate::worksheet::xlsx_err;
 
 /// Column type classification done once (outside the row loop) to avoid
@@ -76,15 +76,17 @@ pub fn write_arrow_batch(
 
     let columns: Vec<ArrayRef> = (0..num_cols).map(|c| batch.column(c).clone()).collect();
     let kinds: Vec<ColKind> = columns.iter().map(|c| classify(c.data_type())).collect();
+    // Per-column format override is fixed for the whole column — resolve once
+    // instead of once per cell in the row×col loop below.
+    let col_overrides: Vec<Option<&Format>> =
+        (0..num_cols).map(|c| crate::format::col_override(col_formats, c)).collect();
 
     for row in 0..num_rows {
         let row_u32 = start_row + row as u32;
         for col_idx in 0..num_cols {
             let col_u16 = col_idx as u16;
             let column = &columns[col_idx];
-
-            // Per-column format override: wins over float_fmt for numeric cols.
-            let col_override = crate::format::col_override(col_formats, col_idx);
+            let col_override = col_overrides[col_idx];
 
             if column.is_null(row) {
                 worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
@@ -94,12 +96,13 @@ pub fn write_arrow_batch(
             macro_rules! write_int {
                 ($ty:ty) => {{
                     let val = column.as_primitive::<$ty>().value(row) as f64;
-                    if let Some(fmt) = col_override {
-                        worksheet.write_number_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
-                    } else {
-                        worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
-                    }
+                    write_number_opt(worksheet, row_u32, col_u16, val, col_override)?;
                 }};
+            }
+            macro_rules! write_str {
+                ($val:expr) => {
+                    write_string_opt(worksheet, row_u32, col_u16, $val, col_override)?
+                };
             }
 
             match kinds[col_idx] {
@@ -113,11 +116,7 @@ pub fn write_arrow_batch(
                 ColKind::UInt64 => write_int!(UInt64Type),
                 ColKind::Float16 => {
                     let val = column.as_primitive::<Float16Type>().value(row).to_f64();
-                    if let Some(fmt) = col_override {
-                        worksheet.write_number_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
-                    } else {
-                        worksheet.write_number(row_u32, col_u16, val).map_err(xlsx_err)?;
-                    }
+                    write_number_opt(worksheet, row_u32, col_u16, val, col_override)?;
                 }
                 ColKind::Float32 => {
                     let val = column.as_primitive::<Float32Type>().value(row) as f64;
@@ -136,30 +135,9 @@ pub fn write_arrow_batch(
                         .write_boolean(row_u32, col_u16, arr.value(row))
                         .map_err(xlsx_err)?;
                 }
-                ColKind::Utf8 => {
-                    let val = column.as_string::<i32>().value(row);
-                    if let Some(fmt) = col_override {
-                        worksheet.write_string_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
-                    } else {
-                        worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
-                    }
-                }
-                ColKind::LargeUtf8 => {
-                    let val = column.as_string::<i64>().value(row);
-                    if let Some(fmt) = col_override {
-                        worksheet.write_string_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
-                    } else {
-                        worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
-                    }
-                }
-                ColKind::Utf8View => {
-                    let val = column.as_string_view().value(row);
-                    if let Some(fmt) = col_override {
-                        worksheet.write_string_with_format(row_u32, col_u16, val, fmt).map_err(xlsx_err)?;
-                    } else {
-                        worksheet.write_string(row_u32, col_u16, val).map_err(xlsx_err)?;
-                    }
-                }
+                ColKind::Utf8 => write_str!(column.as_string::<i32>().value(row)),
+                ColKind::LargeUtf8 => write_str!(column.as_string::<i64>().value(row)),
+                ColKind::Utf8View => write_str!(column.as_string_view().value(row)),
                 ColKind::Date32 => {
                     let days = column.as_primitive::<Date32Type>().value(row);
                     match days_to_excel_date(days as i64) {
@@ -183,20 +161,7 @@ pub fn write_arrow_batch(
                     };
                 }
                 ColKind::Timestamp(unit) => {
-                    let micros = match unit {
-                        TimeUnit::Second => {
-                            column.as_primitive::<TimestampSecondType>().value(row) * 1_000_000
-                        }
-                        TimeUnit::Millisecond => {
-                            column.as_primitive::<TimestampMillisecondType>().value(row) * 1_000
-                        }
-                        TimeUnit::Microsecond => {
-                            column.as_primitive::<TimestampMicrosecondType>().value(row)
-                        }
-                        TimeUnit::Nanosecond => {
-                            column.as_primitive::<TimestampNanosecondType>().value(row) / 1_000
-                        }
-                    };
+                    let micros = timestamp_to_micros(column, unit, row);
                     match micros_to_excel_datetime(micros) {
                         Some(dt) => worksheet
                             .write_datetime(row_u32, col_u16, &dt)
@@ -316,37 +281,41 @@ fn emit_arrow_cell_csv(
             emit_timestamp_csv(output, ms * 1000);
         }
         ColKind::Timestamp(unit) => {
-            let micros = match unit {
-                TimeUnit::Second => {
-                    column.as_primitive::<TimestampSecondType>().value(row) * 1_000_000
-                }
-                TimeUnit::Millisecond => {
-                    column.as_primitive::<TimestampMillisecondType>().value(row) * 1_000
-                }
-                TimeUnit::Microsecond => {
-                    column.as_primitive::<TimestampMicrosecondType>().value(row)
-                }
-                TimeUnit::Nanosecond => {
-                    column.as_primitive::<TimestampNanosecondType>().value(row) / 1_000
-                }
-            };
-            emit_timestamp_csv(output, micros);
+            emit_timestamp_csv(output, timestamp_to_micros(column, unit, row));
         }
         ColKind::Unsupported => {}
     }
 }
 
-fn emit_timestamp_csv(output: &mut Vec<u8>, micros: i64) {
-    use std::io::Write;
+/// Scale an Arrow timestamp column value at `row` to microseconds since epoch,
+/// regardless of its stored `TimeUnit`.
+fn timestamp_to_micros(column: &ArrayRef, unit: TimeUnit, row: usize) -> i64 {
+    match unit {
+        TimeUnit::Second => column.as_primitive::<TimestampSecondType>().value(row) * 1_000_000,
+        TimeUnit::Millisecond => column.as_primitive::<TimestampMillisecondType>().value(row) * 1_000,
+        TimeUnit::Microsecond => column.as_primitive::<TimestampMicrosecondType>().value(row),
+        TimeUnit::Nanosecond => column.as_primitive::<TimestampNanosecondType>().value(row) / 1_000,
+    }
+}
+
+/// Decompose micros-since-epoch into civil `(year, month, day, hour, minute,
+/// second)`. Returns `None` if the date is out of Excel's 0..=9999 range.
+fn micros_to_ymdhms(micros: i64) -> Option<(u16, u8, u8, u16, u8, u8)> {
     let total_secs = micros / 1_000_000;
     let days = total_secs / 86400;
     let day_secs = (total_secs % 86400).unsigned_abs();
-    let Some((y, m, d)) = chrono_from_days(days) else {
+    let (year, month, day) = chrono_from_days(days)?;
+    let hour = (day_secs / 3600) as u16;
+    let minute = ((day_secs % 3600) / 60) as u8;
+    let second = (day_secs % 60) as u8;
+    Some((year, month, day, hour, minute, second))
+}
+
+fn emit_timestamp_csv(output: &mut Vec<u8>, micros: i64) {
+    use std::io::Write;
+    let Some((y, m, d, hour, minute, second)) = micros_to_ymdhms(micros) else {
         return;
     };
-    let hour = day_secs / 3600;
-    let minute = (day_secs % 3600) / 60;
-    let second = day_secs % 60;
     let _ = write!(
         output,
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
@@ -382,15 +351,7 @@ fn millis_to_excel_datetime(ms: i64) -> Option<ExcelDateTime> {
 }
 
 fn micros_to_excel_datetime(micros: i64) -> Option<ExcelDateTime> {
-    let total_secs = micros / 1_000_000;
-    let days = total_secs / 86400;
-    let day_secs = (total_secs % 86400).unsigned_abs();
-
-    let (year, month, day) = chrono_from_days(days)?;
-    let hour = (day_secs / 3600) as u16;
-    let minute = ((day_secs % 3600) / 60) as u8;
-    let second = (day_secs % 60) as u8;
-
+    let (year, month, day, hour, minute, second) = micros_to_ymdhms(micros)?;
     ExcelDateTime::from_ymd(year, month, day)
         .ok()?
         .and_hms(hour, minute, second)

--- a/src/csv_writer.rs
+++ b/src/csv_writer.rs
@@ -123,7 +123,9 @@ pub fn write_csv(
                     headers_written = true;
                 }
 
-                for (col, value) in row_dict.values().iter().enumerate() {
+                // Iterate the dict directly (insertion order == header order)
+                // to avoid allocating a fresh `values()` list per row.
+                for (col, (_key, value)) in row_dict.iter().enumerate() {
                     if col > 0 {
                         output.push(delim_byte);
                     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -141,6 +141,44 @@ pub fn write_num(
     Ok(())
 }
 
+/// Write a numeric cell, with an optional explicit format. Unlike [`write_num`]
+/// this does NOT guard NaN/Inf — callers use it for integer values (and Arrow
+/// integral/float16 columns) that can never be NaN/Inf.
+pub fn write_number_opt(
+    worksheet: &mut Worksheet,
+    row: u32,
+    col: u16,
+    val: f64,
+    fmt: Option<&Format>,
+) -> PyResult<()> {
+    if let Some(fmt) = fmt {
+        worksheet
+            .write_number_with_format(row, col, val, fmt)
+            .map_err(xlsx_err)?;
+    } else {
+        worksheet.write_number(row, col, val).map_err(xlsx_err)?;
+    }
+    Ok(())
+}
+
+/// Write a string cell, with an optional explicit format.
+pub fn write_string_opt(
+    worksheet: &mut Worksheet,
+    row: u32,
+    col: u16,
+    val: &str,
+    fmt: Option<&Format>,
+) -> PyResult<()> {
+    if let Some(fmt) = fmt {
+        worksheet
+            .write_string_with_format(row, col, val, fmt)
+            .map_err(xlsx_err)?;
+    } else {
+        worksheet.write_string(row, col, val).map_err(xlsx_err)?;
+    }
+    Ok(())
+}
+
 /// `true` if `val` begins with a character a spreadsheet may interpret as a
 /// formula (`=`, `+`, `-`, `@`) — the classic CSV-injection vector.
 fn needs_formula_guard(val: &str) -> bool {
@@ -190,7 +228,9 @@ pub fn save_workbook(
     }
 
     let buffer = workbook.save_to_buffer().map_err(|e| {
-        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+        // Match the file-save path (PyIOError) so a save failure surfaces as
+        // OSError regardless of whether the target is a path or a buffer.
+        PyErr::new::<pyo3::exceptions::PyIOError, _>(format!(
             "Failed to save workbook to buffer: {}",
             e
         ))

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -7,7 +7,8 @@ use std::collections::HashSet;
 use crate::cell::{classify_and_write, try_cached, CellWriter};
 use crate::data_types::{FreezePanesConfig, WorksheetData};
 use crate::helpers::{
-    py_date_to_excel, py_datetime_to_excel, save_workbook, write_all_headers, write_num, ColType,
+    py_date_to_excel, py_datetime_to_excel, save_workbook, write_all_headers, write_num,
+    write_number_opt, ColType,
 };
 use crate::utils::ensure_valid_sheet_name;
 
@@ -78,16 +79,7 @@ impl CellWriter for ExcelCell<'_> {
 
     fn write_int(&mut self, i: &Bound<'_, PyInt>) -> PyResult<()> {
         let val: f64 = i.extract()?;
-        if let Some(fmt) = self.col_override {
-            self.worksheet
-                .write_number_with_format(self.row, self.col, val, fmt)
-                .map_err(xlsx_err)?;
-        } else {
-            self.worksheet
-                .write_number(self.row, self.col, val)
-                .map_err(xlsx_err)?;
-        }
-        Ok(())
+        write_number_opt(self.worksheet, self.row, self.col, val, self.col_override)
     }
 
     fn write_datetime(&mut self, dt: &Bound<'_, PyDateTime>) -> PyResult<()> {
@@ -282,7 +274,9 @@ fn write_worksheet_content(
                     }
 
                     let row_u32 = (row_idx + 1) as u32;
-                    for (col, value) in row_dict.values().iter().enumerate() {
+                    // Iterate the dict directly (insertion order == header order)
+                    // to avoid allocating a fresh `values()` list per row.
+                    for (col, (_key, value)) in row_dict.iter().enumerate() {
                         let col_u16 = col as u16;
                         let cached = col_types
                             .get(col)
@@ -442,14 +436,18 @@ where
         })
         .collect();
 
+    // Per-column format override is fixed for the whole column — resolve once
+    // instead of per cell.
+    let col_overrides: Vec<Option<&Format>> = (0..bound_cols.len())
+        .map(|c| crate::format::col_override(col_formats, c))
+        .collect();
+
     for row in 0..nrows {
         let row_u32 = (row + 1) as u32;
         for (col_idx, col_list) in bound_cols.iter().enumerate() {
             let col_u16 = col_idx as u16;
             let item = col_list.get(row)?;
-
-            // Per-column format override: wins over float_fmt for numeric cols.
-            let col_override = crate::format::col_override(col_formats, col_idx);
+            let col_override = col_overrides[col_idx];
 
             if item.is_none() {
                 worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
@@ -459,15 +457,7 @@ where
             match kind_at(col_idx) {
                 ScalarKind::Int => {
                     let val: f64 = item.extract()?;
-                    if let Some(fmt) = col_override {
-                        worksheet
-                            .write_number_with_format(row_u32, col_u16, val, fmt)
-                            .map_err(xlsx_err)?;
-                    } else {
-                        worksheet
-                            .write_number(row_u32, col_u16, val)
-                            .map_err(xlsx_err)?;
-                    }
+                    write_number_opt(worksheet, row_u32, col_u16, val, col_override)?;
                 }
                 ScalarKind::Float => {
                     let val: f64 = item.extract()?;
@@ -644,11 +634,9 @@ pub fn write_worksheets(
             .map(|c| c.resolve(&sheet_name))
             .unwrap_or_default();
 
-        let sheet_uniform: Option<f64> =
-            match keyed_get(column_width.as_ref(), &sheet_name)? {
-                Some(v) => Some(v.extract()?),
-                None => None,
-            };
+        let sheet_uniform: Option<f64> = keyed_get(column_width.as_ref(), &sheet_name)?
+            .map(|v| v.extract())
+            .transpose()?;
         let sheet_spec: Option<Bound<'_, PyAny>> =
             keyed_get(column_widths.as_ref(), &sheet_name)?;
 


### PR DESCRIPTION
…ork)

Quality-only, no behavior change:
- helpers::write_number_opt / write_string_opt — collapse the int-write and Arrow string-write override blocks (was duplicated 4x / 3x).
- arrow_writer: extract timestamp_to_micros + micros_to_ymdhms — remove Timestamp-unit and date-decomposition duplication across Excel/CSV paths.
- Hoist per-column col_override resolution out of the Arrow rows×cols loop and the DataFrame row loop (resolve once per column, not per cell).
- Records (Excel + CSV): iterate row_dict directly instead of allocating a values() list per row.
- save-to-buffer failure now raises PyIOError (matches file-save / OSError).
- keyed_get: collapse one Option-extract match to .map().transpose().

150 unit tests pass; clippy unchanged (no new warnings).

## Summary

<!-- Brief description of what this PR does -->

## Changes

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [ ] `pytest tests/ -m "not benchmark"` passes
- [ ] `cargo check` has no warnings
- [ ] Type stubs (`.pyi`) updated if API changed
- [ ] README updated if applicable
