### PR TITLE
ci: add Dependabot + Release Drafter automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Rust crates (Cargo.toml / Cargo.lock)
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"
+
+  # Python deps declared in pyproject.toml (test extras)
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+
+categories:
+  - title: "🚀 Features"
+    labels: [feature, enhancement]
+  - title: "🐛 Fixes"
+    labels: [fix, bug]
+  - title: "⚡ Performance"
+    labels: [performance, perf]
+  - title: "🧹 Refactor & Maintenance"
+    labels: [refactor, chore, dependencies]
+  - title: "📝 Docs"
+    labels: [docs, documentation]
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+
+# Bare version scheme (no leading 'v'), matching existing tags (0.5.2, ...).
+version-resolver:
+  major:
+    labels: [major, breaking]
+  minor:
+    labels: [minor, feature, enhancement]
+  patch:
+    labels: [patch, fix, bug, perf, performance, refactor, chore, docs, dependencies]
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full changelog:** $PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,10 +1,11 @@
 name: Release Drafter
 
+# Runs only on master: release-drafter reads its config from the default
+# branch, so a PR-triggered run (before the config is merged) always fails.
 on:
   push:
     branches: [master]
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,7 +14,6 @@ jobs:
   update_release_draft:
     permissions:
       contents: write # create/update the draft release
-      pull-requests: write # label autolabeler (categories)
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write # create/update the draft release
+      pull-requests: write # label autolabeler (categories)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automates the two things just done by hand.

## What
- **Dependabot** (`.github/dependabot.yml`): weekly dependency PRs for **cargo**, **github-actions**, and **pip**. Cargo minor+patch updates grouped into one PR to cut noise.
- **Release Drafter** (`.github/release-drafter.yml` + workflow): maintains a draft GitHub Release, auto-categorizing merged PRs by label (Features / Fixes / Performance / Refactor / Docs). Uses the bare-version tag scheme (`0.5.2`, no `v`).

## Notes
- Release Drafter categories key off PR labels; Dependabot adds the `dependencies` label automatically.
- No effect on the existing CI/publish or docs workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)