### PR TITLE
chore: repo polish (docs badge, CodeQL, FUNDING, dependabot grouping)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Shows a "Sponsor" button on the repo if GitHub Sponsors is enabled for the
+# account. Add other platforms (ko_fi, buy_me_a_coffee, custom) as needed.
+github: [rahmadafandi]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
-# Shows a "Sponsor" button on the repo if GitHub Sponsors is enabled for the
-# account. Add other platforms (ko_fi, buy_me_a_coffee, custom) as needed.
-github: [rahmadafandi]
+# Shows a "Sponsor" button on the repo linking to the URLs below.
+# Saweria isn't a built-in platform key, so it goes under `custom`.
+custom: ["https://saweria.co/rahmadafandi"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,18 +12,25 @@ updates:
       cargo-minor-patch:
         update-types: ["minor", "patch"]
 
-  # GitHub Actions used in workflows
+  # GitHub Actions used in workflows — batch all updates into one PR/week.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns: ["*"]
 
-  # Python deps declared in pyproject.toml (test extras)
+  # Python deps (requirements.txt + pyproject test extras) — batch minor+patch.
   - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "27 4 * * 1" # weekly, Monday 04:27 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # The Python wrapper. (The Rust core's dependency advisories are
+        # covered by Dependabot's cargo security updates.)
+        language: [python]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          language: ${{ matrix.language }}
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://pepy.tech/badge/rustpy-xlsxwriter)](https://pepy.tech/project/rustpy-xlsxwriter)
 [![CI](https://github.com/rahmadafandi/rustpy-xlsxwriter/actions/workflows/CI.yml/badge.svg)](https://github.com/rahmadafandi/rustpy-xlsxwriter/actions/workflows/CI.yml)
+[![Docs](https://img.shields.io/badge/docs-API%20reference-blue)](https://rahmadafandi.github.io/rustpy-xlsxwriter/)
 
 High-performance Excel and CSV file generation for Python, powered by Rust. **~7x-9x faster** than [XlsxWriter](https://github.com/jmcnamara/XlsxWriter), **~5x faster** CSV (records) than Python's `csv` module, and **~12x faster** Pandas DataFrame → CSV than `pandas.to_csv` via zero-copy Arrow.
 


### PR DESCRIPTION
Follow-up repo hygiene.

- **README**: API-docs badge → https://rahmadafandi.github.io/rustpy-xlsxwriter/
- **CodeQL** (`.github/workflows/codeql.yml`): static analysis for the Python wrapper, weekly + on push/PR.
- **FUNDING.yml**: Sponsor button (`github: rahmadafandi`).
- **Dependabot grouping**: batch github-actions (all) and pip (minor+patch) into single weekly PRs — the first run opened 10 separate PRs; grouping prevents that going forward.

Live settings already applied out-of-band: auto-delete merged branches ✅, release-drafter labels (feature/fix/performance/refactor/chore) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)