### PR TITLE
feat(excel): add per-sheet dedupe_strings option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "rustpy-xlsxwriter"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpy-xlsxwriter"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 authors = ["Rahmad Afandi <rahmadafandiii@gmail.com>"]
 description = "High-performance Excel and CSV file generation powered by Rust (~7-9x faster)"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,41 @@ accept `"#RRGGBB"` or names (`"red"`); enum-valued setters take lowercase string
 > show the raw Excel serial number — chain `.set_num_format("yyyy-mm-dd")` (or
 > similar) to keep a date display.
 
+### String Deduplication
+
+By default every sheet is written in constant-memory mode: strings go inline
+into the sheet XML and nothing is buffered. Passing `dedupe_strings=True` takes
+that sheet out of constant-memory mode and stores each distinct string once in
+the workbook's shared-string table instead.
+
+```python
+(
+    FastExcel("report.xlsx")
+    .sheet("Events", events, dedupe_strings=True)   # lots of repeated text
+    .sheet("Raw", raw_rows)                         # default: streamed
+    .save()
+)
+```
+
+Measured on 50k rows — the uncompressed XML shrinks a lot, but `.xlsx` is a zip
+and deflate already collapses repetition, so the **on-disk** win is modest and
+can even be negative:
+
+| Data | Uncompressed | On disk | Write time |
+|---|---|---|---|
+| Short repeats (4 distinct values) | −11% | **+2%** | 1.7x |
+| Long repeats (20 distinct, 120 chars) | −56% | −5% | 1.1x |
+| All-unique strings | +11% | −1% | 1.5x |
+| 20 repeated text columns | −39% | −9% | 1.1x |
+
+Worth enabling for sheets with many repeated *long* strings, or when the
+consumer parses the uncompressed XML. Not worth it for short categorical values.
+Off by default because it buffers the whole sheet in memory — measure on your
+own data before turning it on for a large export.
+
+For `write_worksheets`, pass `dedupe_strings` as a dict keyed by sheet name
+(with a `"general"` fallback key).
+
 ### Generator Streaming
 
 ```python
@@ -198,6 +233,9 @@ def rows():
 
 FastExcel("streamed.xlsx").sheet("Data", rows()).save()
 ```
+
+> **Note:** `dedupe_strings=True` buffers the sheet, so it defeats the point of
+> generator streaming. Leave it off for very large streamed exports.
 
 ### In-Memory Buffer (Web Frameworks)
 

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -191,9 +191,10 @@ class FastExcel:
                 protection is trivially removed; do not rely on it to keep
                 data confidential.
             autofit: Automatically adjust column widths (default ``True``).
-                Under constant-memory mode (used by this library for all
-                Excel paths) autofit sizing is approximate. Set to
-                ``False`` for large datasets to improve performance.
+                Under constant-memory mode (the default for every Excel sheet,
+                unless ``sheet(..., dedupe_strings=True)`` opts out) autofit
+                sizing is approximate. Set to ``False`` for large datasets to
+                improve performance.
             sanitize_formulas: CSV/TSV only. When ``True``, string fields that
                 begin with ``= + - @`` are prefixed with a single quote so
                 spreadsheet apps open them as text instead of executing them as
@@ -215,6 +216,7 @@ class FastExcel:
         self._col_widths: Dict[str, Union[Dict[str, float], List[float]]] = {}
         self._col_formats: Dict[str, Any] = {}
         self._header_format: Dict[str, Any] = {}
+        self._dedupe_strings: Dict[str, bool] = {}
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -288,6 +290,7 @@ class FastExcel:
         column_widths: Optional[Union[Dict[str, float], List[float]]] = None,
         column_formats: Optional[Union[Dict[str, "Format"], List["Format"]]] = None,
         header_format: Optional["Format"] = None,
+        dedupe_strings: bool = False,
     ) -> "FastExcel":
         """Add a worksheet with data.
 
@@ -303,11 +306,20 @@ class FastExcel:
                 (``[Format().set_bold(), None]``).
             header_format: :class:`Format` applied to every header cell of this
                 sheet.
+            dedupe_strings: Store repeated strings once in the workbook's
+                shared-string table instead of inline, which can shrink the
+                ``.xlsx`` substantially when a sheet has many repeated text
+                values (categories, statuses, country codes). Off by default:
+                it takes this sheet out of constant-memory mode, so the whole
+                sheet is buffered in RAM and every string is hashed. Turn it on
+                per sheet, for sheets whose text actually repeats, and measure.
 
         Raises:
             ValueError: If the sheet name is invalid (validated on save).
         """
         self._sheets.append((name, data))
+        if dedupe_strings:
+            self._dedupe_strings[name] = True
         if column_width is not None:
             self._col_width[name] = column_width
         if column_widths is not None:
@@ -385,6 +397,7 @@ class FastExcel:
                 column_widths=cws,
                 column_formats=self._col_formats.get(sheet_name),
                 header_format=self._header_format.get(sheet_name),
+                dedupe_strings=self._dedupe_strings.get(sheet_name, False),
             )
         else:
             # Multi-sheet path
@@ -402,6 +415,7 @@ class FastExcel:
                 column_widths=self._col_widths or None,
                 column_formats=self._col_formats or None,
                 header_format=self._header_format or None,
+                dedupe_strings=self._dedupe_strings or None,
             )
 
 

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -272,6 +272,7 @@ def write_worksheet(
     column_widths: Optional[ColumnWidths] = None,
     column_formats: Optional[ColumnFormats] = None,
     header_format: Optional[Format] = None,
+    dedupe_strings: bool = False,
 ) -> None:
     """Write data to a **single** worksheet in an Excel file.
 
@@ -290,6 +291,10 @@ def write_worksheet(
         autofit: Automatically adjust column widths (default ``True``).
         column_width: Uniform width applied to every column.
         column_widths: Per-column width — a dict keyed by header name or a positional list.
+        dedupe_strings: Store repeated strings once in the shared-string table
+            instead of inline. Shrinks files with heavily repeated text, at the
+            cost of buffering the sheet in memory (disables constant-memory
+            mode). Off by default.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -314,6 +319,7 @@ def write_worksheets(
     column_widths: Optional[Dict[str, ColumnWidths]] = None,
     column_formats: Optional[Dict[str, ColumnFormats]] = None,
     header_format: Optional[Dict[str, Format]] = None,
+    dedupe_strings: Optional[Dict[str, bool]] = None,
 ) -> None:
     """Write data to **multiple** worksheets in an Excel file.
 
@@ -327,6 +333,9 @@ def write_worksheets(
         autofit: Automatically adjust column widths (default ``True``).
         column_width: Uniform width per sheet — dict keyed by sheet name (``"general"`` applies to all).
         column_widths: Per-column width per sheet — dict keyed by sheet name mapping to :data:`ColumnWidths`.
+        dedupe_strings: Per-sheet shared-string deduplication — dict keyed by
+            sheet name (``"general"`` applies to all). See
+            :func:`write_worksheet` for the trade-off.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -397,7 +397,7 @@ def validate_sheet_name(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def get_version() -> str:
-    """Return the package version string (e.g. ``'0.5.2'``)."""
+    """Return the package version string (e.g. ``'0.6.0'``)."""
     ...
 
 def get_name() -> str:

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -605,7 +605,7 @@ fn keyed_get<'py>(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None))]
+#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None))]
 pub fn write_worksheets(
     py: Python,
     records_with_sheet_name: Vec<(String, WorksheetData)>,
@@ -621,12 +621,22 @@ pub fn write_worksheets(
     column_widths: Option<Bound<'_, pyo3::types::PyDict>>,
     column_formats: Option<Bound<'_, pyo3::types::PyDict>>,
     header_format: Option<Bound<'_, pyo3::types::PyDict>>,
+    dedupe_strings: Option<Bound<'_, pyo3::types::PyDict>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     for (sheet_name, records) in records_with_sheet_name {
         ensure_valid_sheet_name(&sheet_name)?;
 
-        let mut worksheet = workbook.add_worksheet_with_constant_memory();
+        let dedupe = keyed_get(dedupe_strings.as_ref(), &sheet_name)?
+            .map(|v| v.extract::<bool>())
+            .transpose()?
+            .unwrap_or(false);
+
+        let mut worksheet = if dedupe {
+            workbook.add_worksheet()
+        } else {
+            workbook.add_worksheet_with_constant_memory()
+        };
         worksheet.set_name(&sheet_name).map_err(xlsx_err)?;
 
         let pane = freeze_panes
@@ -673,7 +683,7 @@ pub fn write_worksheets(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None))]
+#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false))]
 pub fn write_worksheet(
     py: Python,
     records: WorksheetData,
@@ -691,9 +701,14 @@ pub fn write_worksheet(
     column_widths: Option<Bound<'_, PyAny>>,
     column_formats: Option<Bound<'_, PyAny>>,
     header_format: Option<Bound<'_, crate::format::Format>>,
+    dedupe_strings: bool,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
-    let mut worksheet = workbook.add_worksheet_with_constant_memory();
+    let mut worksheet = if dedupe_strings {
+        workbook.add_worksheet()
+    } else {
+        workbook.add_worksheet_with_constant_memory()
+    };
 
     if let Some(sheet_name) = sheet_name {
         ensure_valid_sheet_name(&sheet_name)?;

--- a/tests/test_dedupe_strings.py
+++ b/tests/test_dedupe_strings.py
@@ -1,0 +1,126 @@
+"""Shared-string deduplication (``dedupe_strings=``)."""
+
+import zipfile
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, write_worksheet, write_worksheets
+
+
+def _repetitive_records(n=2000):
+    statuses = ["pending", "shipped", "delivered", "cancelled"]
+    return [
+        {"id": i, "status": statuses[i % len(statuses)], "note": "no remarks"}
+        for i in range(n)
+    ]
+
+
+def _shared_strings(path):
+    """Return the raw xl/sharedStrings.xml, or None when absent."""
+    with zipfile.ZipFile(path) as z:
+        if "xl/sharedStrings.xml" not in z.namelist():
+            return None
+        return z.read("xl/sharedStrings.xml").decode("utf-8")
+
+
+def test_off_by_default_writes_inline_strings(tmp_path):
+    path = tmp_path / "inline.xlsx"
+    write_worksheet(_repetitive_records(), str(path))
+    assert _shared_strings(path) is None
+
+
+def test_dedupe_builds_shared_string_table(tmp_path):
+    path = tmp_path / "shared.xlsx"
+    write_worksheet(_repetitive_records(), str(path), dedupe_strings=True)
+
+    xml = _shared_strings(path)
+    assert xml is not None
+    # 4 statuses + 1 note + 3 headers, each stored exactly once.
+    assert 'uniqueCount="8"' in xml
+    assert xml.count("<t>delivered</t>") == 1
+
+
+def _uncompressed_size(path):
+    with zipfile.ZipFile(path) as z:
+        return sum(i.file_size for i in z.infolist())
+
+
+def test_dedupe_shrinks_repeated_text(tmp_path):
+    """Long repeated strings are the case dedup is actually for.
+
+    Note the win is on the *uncompressed* XML; ``.xlsx`` is a zip and deflate
+    already collapses repetition, so the on-disk saving is far smaller — and
+    for short repeated strings the shared-string table costs more than it
+    saves. See ``test_short_repeats_do_not_shrink_on_disk``.
+    """
+    inline = tmp_path / "inline.xlsx"
+    shared = tmp_path / "shared.xlsx"
+    long_values = [f"{c}-{'x' * 120}" for c in "abcde"]
+    records = [{"id": i, "s": long_values[i % 5]} for i in range(5000)]
+
+    write_worksheet(records, str(inline))
+    write_worksheet(records, str(shared), dedupe_strings=True)
+
+    assert _uncompressed_size(shared) < _uncompressed_size(inline) / 2
+    assert shared.stat().st_size < inline.stat().st_size
+
+
+def test_short_repeats_do_not_shrink_on_disk(tmp_path):
+    """Guards the documented caveat: dedup is not a free win."""
+    inline = tmp_path / "inline.xlsx"
+    shared = tmp_path / "shared.xlsx"
+    records = _repetitive_records()
+
+    write_worksheet(records, str(inline))
+    write_worksheet(records, str(shared), dedupe_strings=True)
+
+    # Uncompressed XML still shrinks...
+    assert _uncompressed_size(shared) < _uncompressed_size(inline)
+    # ...but after zip compression the table is pure overhead here.
+    assert shared.stat().st_size >= inline.stat().st_size
+
+
+def test_dedupe_preserves_cell_values(tmp_path):
+    path = tmp_path / "values.xlsx"
+    records = _repetitive_records(10)
+    write_worksheet(records, str(path), sheet_name="Data", dedupe_strings=True)
+
+    ws = openpyxl.load_workbook(path)["Data"]
+    assert [c.value for c in ws[1]] == ["id", "status", "note"]
+    for row_idx, record in enumerate(records, start=2):
+        assert ws.cell(row=row_idx, column=1).value == record["id"]
+        assert ws.cell(row=row_idx, column=2).value == record["status"]
+        assert ws.cell(row=row_idx, column=3).value == record["note"]
+
+
+@pytest.mark.parametrize("key", ["Repeats", "general"])
+def test_multi_sheet_dedupe_is_per_sheet(tmp_path, key):
+    path = tmp_path / "multi.xlsx"
+    write_worksheets(
+        [("Repeats", _repetitive_records(200)), ("Other", [{"x": "unique"}])],
+        str(path),
+        dedupe_strings={key: True},
+    )
+
+    xml = _shared_strings(path)
+    assert xml is not None
+    assert "<t>delivered</t>" in xml
+    # "unique" only lands in the table when dedup applies to every sheet.
+    assert ("<t>unique</t>" in xml) == (key == "general")
+
+
+def test_fastexcel_sheet_flag(tmp_path):
+    path = tmp_path / "builder.xlsx"
+    (
+        FastExcel(str(path))
+        .sheet("Data", _repetitive_records(200), dedupe_strings=True)
+        .save()
+    )
+    assert _shared_strings(path) is not None
+
+
+def test_fastexcel_default_stays_constant_memory(tmp_path):
+    path = tmp_path / "builder-default.xlsx"
+    FastExcel(str(path)).sheet("Data", _repetitive_records(200)).save()
+    assert _shared_strings(path) is None


### PR DESCRIPTION
Closes #50

Adds an opt-in per-sheet flag that stores each distinct string once in the workbook's shared-string table instead of writing it inline.

```python
(
    FastExcel("report.xlsx")
    .sheet("Events", events, dedupe_strings=True)   # lots of repeated text
    .sheet("Raw", raw_rows)                         # default: streamed
    .save()
)
```

`write_worksheet` takes a bool; `write_worksheets` takes a dict keyed by sheet name with the usual `"general"` fallback.

## Why per-sheet and not per-column

The issue proposes `deduplicate_strings_in=["column_foo", "column_bar"]`. That is not expressible: the shared-string table is a workbook-level part of the `.xlsx` format, and `rust_xlsxwriter` exposes it as a per-worksheet all-or-nothing choice (`add_worksheet()` vs `add_worksheet_with_constant_memory()`). There is no hook to route only some columns through it.

So the flag is a per-sheet bool. It stays off by default, which preserves the memory-safety property the issue asked for — a sheet only leaves constant-memory mode when explicitly told to.

## Measured impact

The issue's premise is that this yields smaller files. That mostly does not hold on disk. `.xlsx` is a zip, and deflate already collapses repeated strings, so the shared-string table often just adds indirection. 50k rows:

| Data | Uncompressed XML | On disk | Write time |
|---|---|---|---|
| Short repeats (4 distinct values) | −11% | **+2%** | 1.7x |
| Long repeats (20 distinct, 120 chars) | −56% | −5% | 1.1x |
| All-unique strings | +11% | −1% | 1.5x |
| 20 repeated text columns | −39% | −9% | 1.1x |

The uncompressed win is real and large, which matters when the consumer parses the sheet XML directly or holds it in memory. The on-disk win is modest, and negative for short categorical values.

Both directions are documented in the README and pinned by tests, including `test_short_repeats_do_not_shrink_on_disk` so the caveat cannot silently rot.

## Verification

```
cargo build --release            → OK
cargo clippy --release           → 14 warnings, same as master (none new)
pytest tests/ -m "not benchmark" → 159 passed (9 new)
```

Tests assert on `xl/sharedStrings.xml` presence and `uniqueCount` rather than file size alone.

## Version

Bumped to `0.6.0` (minor — new public API), matching the convention used for the Arrow (`0.2.0`) and CSV (`0.4.0`) features.
