### PR TITLE
feat(excel): merged cells, row heights, row formats, banded rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,56 @@ accept `"#RRGGBB"` or names (`"red"`); enum-valued setters take lowercase string
 > show the raw Excel serial number — chain `.set_num_format("yyyy-mm-dd")` (or
 > similar) to keep a date display.
 
+### Row Layout: Merged Headers, Borders, Banding
+
+Crosstab and summary reports need structure above and across the data rows.
+Everything here is declared up front, per sheet:
+
+```python
+from rustpy_xlsxwriter import FastExcel, Format
+
+banner = Format().set_bold().set_align("center").set_background_color("#1F4E78")
+under_header = Format().set_border_bottom("thin")
+
+(
+    FastExcel("crosstab.xlsx")
+    .sheet(
+        "Survey",
+        rows,
+        header_row=1,                                    # leave row 0 for banners
+        merge_ranges=[(0, 1, 0, 2, "Gender", banner)],   # "Gender" spans B:C
+        row_heights={0: 28, 1: 22},
+        row_formats={1: under_header},                   # rule under the header
+        banded_rows="#F2F2F2",                           # alternating fill
+    )
+    .save()
+)
+```
+
+| Option | Effect |
+|---|---|
+| `header_row` | 0-based row for headers; data starts on the next row |
+| `merge_ranges` | `(first_row, first_col, last_row, last_col, value[, format])` |
+| `row_heights` | `{row_index: height}` in points |
+| `row_formats` | `{row_index: Format}` — borders under headers, above totals |
+| `banded_rows` | Background colour for every other data row |
+
+**Ordering is enforced, not assumed.** Sheets are written row by row and a row
+that has been flushed cannot be revisited — `rust_xlsxwriter` would drop a late
+`merge_range` with only a message on stderr. So a merge range that reaches
+`header_row` or below raises `ValueError` telling you what to raise
+`header_row` to, rather than silently losing the banner.
+
+**Banding is applied per cell, not per row.** A cell carrying its own format
+ignores the row's, so shading a row with `set_row_format` leaves holes in
+exactly the columns that have a number format. `banded_rows` instead shades
+each cell, so float, integer, boolean, datetime and explicitly-formatted
+columns all stay banded. That costs roughly 20% write time; leave it off when
+you don't need it.
+
+For `write_worksheets`, every one of these takes a dict keyed by sheet name
+(with a `"general"` fallback key).
+
 ### String Deduplication
 
 By default every sheet is written in constant-memory mode: strings go inline

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -217,6 +217,11 @@ class FastExcel:
         self._col_formats: Dict[str, Any] = {}
         self._header_format: Dict[str, Any] = {}
         self._dedupe_strings: Dict[str, bool] = {}
+        self._header_row: Dict[str, int] = {}
+        self._merge_ranges: Dict[str, Any] = {}
+        self._row_heights: Dict[str, Dict[int, float]] = {}
+        self._row_formats: Dict[str, Dict[int, Any]] = {}
+        self._banded_rows: Dict[str, str] = {}
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -291,6 +296,11 @@ class FastExcel:
         column_formats: Optional[Union[Dict[str, "Format"], List["Format"]]] = None,
         header_format: Optional["Format"] = None,
         dedupe_strings: bool = False,
+        header_row: int = 0,
+        merge_ranges: Optional[List[Tuple]] = None,
+        row_heights: Optional[Dict[int, float]] = None,
+        row_formats: Optional[Dict[int, "Format"]] = None,
+        banded_rows: Optional[str] = None,
     ) -> "FastExcel":
         """Add a worksheet with data.
 
@@ -313,13 +323,41 @@ class FastExcel:
                 it takes this sheet out of constant-memory mode, so the whole
                 sheet is buffered in RAM and every string is hashed. Turn it on
                 per sheet, for sheets whose text actually repeats, and measure.
+            header_row: 0-based row the header is written on; data follows it.
+                Raise it to leave room for merged banner headers above.
+            merge_ranges: Merged cells, as
+                ``(first_row, first_col, last_row, last_col, value[, format])``
+                tuples — e.g. ``[(0, 1, 0, 2, "Gender", banner_fmt)]`` for a
+                banner spanning two sub-columns. Ranges must sit strictly above
+                ``header_row``; anything overlapping the header or data raises,
+                because rows already written cannot be merged after the fact.
+            row_heights: ``{row_index: height}`` in points.
+            row_formats: ``{row_index: Format}`` applied to the whole row — the
+                way to put a bottom border under the header or a top border
+                above a totals row. A cell carrying its own format (a number
+                format, a column format, a band) wins over the row's.
+            banded_rows: Background colour (``"#F2F2F2"`` or a name) shaded onto
+                every other data row, starting with the second. Applied per cell
+                rather than per row, so columns with their own number format
+                stay shaded too.
 
         Raises:
-            ValueError: If the sheet name is invalid (validated on save).
+            ValueError: If the sheet name is invalid (validated on save), or a
+                merge range overlaps the header/data rows.
         """
         self._sheets.append((name, data))
         if dedupe_strings:
             self._dedupe_strings[name] = True
+        if header_row:
+            self._header_row[name] = header_row
+        if merge_ranges is not None:
+            self._merge_ranges[name] = merge_ranges
+        if row_heights is not None:
+            self._row_heights[name] = row_heights
+        if row_formats is not None:
+            self._row_formats[name] = row_formats
+        if banded_rows is not None:
+            self._banded_rows[name] = banded_rows
         if column_width is not None:
             self._col_width[name] = column_width
         if column_widths is not None:
@@ -398,6 +436,11 @@ class FastExcel:
                 column_formats=self._col_formats.get(sheet_name),
                 header_format=self._header_format.get(sheet_name),
                 dedupe_strings=self._dedupe_strings.get(sheet_name, False),
+                header_row=self._header_row.get(sheet_name, 0),
+                merge_ranges=self._merge_ranges.get(sheet_name),
+                row_heights=self._row_heights.get(sheet_name),
+                row_formats=self._row_formats.get(sheet_name),
+                banded_rows=self._banded_rows.get(sheet_name),
             )
         else:
             # Multi-sheet path
@@ -416,6 +459,11 @@ class FastExcel:
                 column_formats=self._col_formats or None,
                 header_format=self._header_format or None,
                 dedupe_strings=self._dedupe_strings or None,
+                header_row=self._header_row or None,
+                merge_ranges=self._merge_ranges or None,
+                row_heights=self._row_heights or None,
+                row_formats=self._row_formats or None,
+                banded_rows=self._banded_rows or None,
             )
 
 

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -50,6 +50,13 @@ ColumnWidths = Union[Dict[str, float], List[float]]
 ColumnFormats = Union[Dict[str, "Format"], List["Format"]]
 """Per-column formats — a dict keyed by header name or a positional list of :class:`Format`."""
 
+MergeRange = Union[
+    Tuple[int, int, int, int, Any],
+    Tuple[int, int, int, int, Any, Optional["Format"]],
+]
+"""One merged cell range: ``(first_row, first_col, last_row, last_col, value)``,
+optionally followed by a :class:`Format`."""
+
 SheetData = Union[Records, DataFrame]
 """Data accepted per sheet – either :data:`Records` or a :data:`DataFrame`."""
 
@@ -273,6 +280,11 @@ def write_worksheet(
     column_formats: Optional[ColumnFormats] = None,
     header_format: Optional[Format] = None,
     dedupe_strings: bool = False,
+    header_row: int = 0,
+    merge_ranges: Optional[List[MergeRange]] = None,
+    row_heights: Optional[Dict[int, float]] = None,
+    row_formats: Optional[Dict[int, Format]] = None,
+    banded_rows: Optional[str] = None,
 ) -> None:
     """Write data to a **single** worksheet in an Excel file.
 
@@ -295,6 +307,12 @@ def write_worksheet(
             instead of inline. Shrinks files with heavily repeated text, at the
             cost of buffering the sheet in memory (disables constant-memory
             mode). Off by default.
+        header_row: 0-based row the header is written on; data follows it.
+        merge_ranges: ``(first_row, first_col, last_row, last_col, value[, format])``
+            tuples. Must sit strictly above ``header_row``.
+        row_heights: ``{row_index: height}`` in points.
+        row_formats: ``{row_index: Format}`` applied to the whole row.
+        banded_rows: Background colour shaded onto every other data row.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -320,6 +338,11 @@ def write_worksheets(
     column_formats: Optional[Dict[str, ColumnFormats]] = None,
     header_format: Optional[Dict[str, Format]] = None,
     dedupe_strings: Optional[Dict[str, bool]] = None,
+    header_row: Optional[Dict[str, int]] = None,
+    merge_ranges: Optional[Dict[str, List[MergeRange]]] = None,
+    row_heights: Optional[Dict[str, Dict[int, float]]] = None,
+    row_formats: Optional[Dict[str, Dict[int, Format]]] = None,
+    banded_rows: Optional[Dict[str, str]] = None,
 ) -> None:
     """Write data to **multiple** worksheets in an Excel file.
 
@@ -336,6 +359,11 @@ def write_worksheets(
         dedupe_strings: Per-sheet shared-string deduplication — dict keyed by
             sheet name (``"general"`` applies to all). See
             :func:`write_worksheet` for the trade-off.
+        header_row: Per-sheet header row index — dict keyed by sheet name.
+        merge_ranges: Per-sheet merged cells — dict keyed by sheet name.
+        row_heights: Per-sheet row heights — dict keyed by sheet name.
+        row_formats: Per-sheet row formats — dict keyed by sheet name.
+        banded_rows: Per-sheet alternating row colour — dict keyed by sheet name.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.

--- a/src/arrow_writer.rs
+++ b/src/arrow_writer.rs
@@ -5,7 +5,9 @@ use arrow_schema::{DataType, TimeUnit};
 use pyo3::prelude::*;
 use rust_xlsxwriter::{ExcelDateTime, Format, Worksheet};
 
-use crate::helpers::{write_csv_escaped_guarded, write_num, write_number_opt, write_string_opt};
+use crate::helpers::{
+    write_bool_opt, write_csv_escaped_guarded, write_num, write_number_opt, write_string_opt,
+};
 use crate::worksheet::xlsx_err;
 
 /// Column type classification done once (outside the row loop) to avoid
@@ -64,32 +66,74 @@ fn classify(dt: &DataType) -> ColKind {
 /// `column_formats`. When a column has an explicit format, it wins over
 /// `float_fmt` for numeric columns. Pass an empty slice when no overrides
 /// are needed (byte-identical behaviour).
+/// Write one temporal cell, falling back to a blank when the value is out of
+/// Excel's range. `dt_fmt` is only attached when banding is on — otherwise the
+/// column format set before the first row already carries the number format.
+#[allow(clippy::too_many_arguments)]
+fn write_temporal(
+    worksheet: &mut Worksheet,
+    row: u32,
+    col: u16,
+    value: Option<rust_xlsxwriter::ExcelDateTime>,
+    banding: bool,
+    dt_fmt: &Format,
+    text_fmt: Option<&Format>,
+) -> PyResult<()> {
+    match value {
+        Some(dt) => crate::helpers::write_datetime_opt(
+            worksheet,
+            row,
+            col,
+            &dt,
+            banding.then_some(dt_fmt),
+        ),
+        None => write_string_opt(worksheet, row, col, "", text_fmt),
+    }
+}
+
 pub fn write_arrow_batch(
     worksheet: &mut Worksheet,
     batch: &RecordBatch,
     start_row: u32,
-    float_fmt: Option<&Format>,
-    col_formats: &[Option<crate::format::Format>],
+    plain: &crate::format::RowPalette,
+    banded: Option<&crate::format::RowPalette>,
+    layout: &crate::helpers::SheetLayout,
 ) -> PyResult<()> {
     let num_cols = batch.num_columns();
     let num_rows = batch.num_rows();
 
     let columns: Vec<ArrayRef> = (0..num_cols).map(|c| batch.column(c).clone()).collect();
     let kinds: Vec<ColKind> = columns.iter().map(|c| classify(c.data_type())).collect();
-    // Per-column format override is fixed for the whole column — resolve once
-    // instead of once per cell in the row×col loop below.
-    let col_overrides: Vec<Option<&Format>> =
-        (0..num_cols).map(|c| crate::format::col_override(col_formats, c)).collect();
+    // Per-column format override is fixed for the whole column *within a
+    // palette* — resolve both variants once instead of per cell in the row×col
+    // loop below.
+    let plain_cols: Vec<Option<&Format>> = (0..num_cols).map(|c| plain.col(c)).collect();
+    let banded_cols: Vec<Option<&Format>> = match banded {
+        Some(b) => (0..num_cols).map(|c| b.col(c)).collect(),
+        None => Vec::new(),
+    };
+    let banding = layout.band_color.is_some();
 
     for row in 0..num_rows {
         let row_u32 = start_row + row as u32;
+        let use_band = layout.is_banded(row_u32);
+        let pal = if use_band { banded.unwrap_or(plain) } else { plain };
+        let overrides = if use_band && banded.is_some() {
+            &banded_cols
+        } else {
+            &plain_cols
+        };
+        // On a band row this carries the fill for cells that would otherwise
+        // be written unformatted.
+        let text_fmt = pal.text.as_ref();
+
         for col_idx in 0..num_cols {
             let col_u16 = col_idx as u16;
             let column = &columns[col_idx];
-            let col_override = col_overrides[col_idx];
+            let col_override = overrides[col_idx].or(text_fmt);
 
             if column.is_null(row) {
-                worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
+                write_string_opt(worksheet, row_u32, col_u16, "", text_fmt)?;
                 continue;
             }
 
@@ -120,59 +164,74 @@ pub fn write_arrow_batch(
                 }
                 ColKind::Float32 => {
                     let val = column.as_primitive::<Float32Type>().value(row) as f64;
-                    write_num(worksheet, row_u32, col_u16, val, col_override.or(float_fmt))?;
+                    write_num(
+                        worksheet,
+                        row_u32,
+                        col_u16,
+                        val,
+                        overrides[col_idx].or(pal.float.as_ref()),
+                    )?;
                 }
                 ColKind::Float64 => {
                     let val = column.as_primitive::<Float64Type>().value(row);
-                    write_num(worksheet, row_u32, col_u16, val, col_override.or(float_fmt))?;
+                    write_num(
+                        worksheet,
+                        row_u32,
+                        col_u16,
+                        val,
+                        overrides[col_idx].or(pal.float.as_ref()),
+                    )?;
                 }
                 ColKind::Bool => {
                     let arr = column
                         .as_any()
                         .downcast_ref::<BooleanArray>()
                         .expect("Boolean dtype guarantees downcast");
-                    worksheet
-                        .write_boolean(row_u32, col_u16, arr.value(row))
-                        .map_err(xlsx_err)?;
+                    write_bool_opt(worksheet, row_u32, col_u16, arr.value(row), text_fmt)?;
                 }
                 ColKind::Utf8 => write_str!(column.as_string::<i32>().value(row)),
                 ColKind::LargeUtf8 => write_str!(column.as_string::<i64>().value(row)),
                 ColKind::Utf8View => write_str!(column.as_string_view().value(row)),
+                // With banding the shade has to ride on the cell: the datetime
+                // column format set up front is fixed for every row.
                 ColKind::Date32 => {
                     let days = column.as_primitive::<Date32Type>().value(row);
-                    match days_to_excel_date(days as i64) {
-                        Some(dt) => worksheet
-                            .write_datetime(row_u32, col_u16, &dt)
-                            .map_err(xlsx_err)?,
-                        None => worksheet
-                            .write_string(row_u32, col_u16, "")
-                            .map_err(xlsx_err)?,
-                    };
+                    write_temporal(
+                        worksheet,
+                        row_u32,
+                        col_u16,
+                        days_to_excel_date(days as i64),
+                        banding,
+                        overrides[col_idx].unwrap_or(&pal.datetime),
+                        text_fmt,
+                    )?;
                 }
                 ColKind::Date64 => {
                     let ms = column.as_primitive::<Date64Type>().value(row);
-                    match millis_to_excel_datetime(ms) {
-                        Some(dt) => worksheet
-                            .write_datetime(row_u32, col_u16, &dt)
-                            .map_err(xlsx_err)?,
-                        None => worksheet
-                            .write_string(row_u32, col_u16, "")
-                            .map_err(xlsx_err)?,
-                    };
+                    write_temporal(
+                        worksheet,
+                        row_u32,
+                        col_u16,
+                        millis_to_excel_datetime(ms),
+                        banding,
+                        overrides[col_idx].unwrap_or(&pal.datetime),
+                        text_fmt,
+                    )?;
                 }
                 ColKind::Timestamp(unit) => {
                     let micros = timestamp_to_micros(column, unit, row);
-                    match micros_to_excel_datetime(micros) {
-                        Some(dt) => worksheet
-                            .write_datetime(row_u32, col_u16, &dt)
-                            .map_err(xlsx_err)?,
-                        None => worksheet
-                            .write_string(row_u32, col_u16, "")
-                            .map_err(xlsx_err)?,
-                    };
+                    write_temporal(
+                        worksheet,
+                        row_u32,
+                        col_u16,
+                        micros_to_excel_datetime(micros),
+                        banding,
+                        overrides[col_idx].unwrap_or(&pal.datetime),
+                        text_fmt,
+                    )?;
                 }
                 ColKind::Unsupported => {
-                    worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
+                    write_string_opt(worksheet, row_u32, col_u16, "", text_fmt)?;
                 }
             }
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -309,6 +309,70 @@ format_methods! {
     ],
 }
 
+/// Every format a data row can need, pre-resolved. Two of these are built per
+/// sheet — plain and banded — and picked by row parity.
+///
+/// Banding deliberately does *not* go through `Worksheet::set_row_format`: a
+/// cell written with its own format ignores the row's, so a column carrying a
+/// number format comes out unshaded and the banding looks broken. Every cell on
+/// a band row instead gets an explicit format that already carries the fill.
+pub struct RowPalette {
+    /// For strings, bools and blanks — cells that otherwise carry no format.
+    pub text: Option<XlsxFormat>,
+    pub float: Option<XlsxFormat>,
+    pub datetime: XlsxFormat,
+    pub cols: Vec<Option<Format>>,
+}
+
+impl RowPalette {
+    /// Borrow the column override for `idx`, mirroring [`col_override`].
+    pub fn col(&self, idx: usize) -> Option<&XlsxFormat> {
+        col_override(&self.cols, idx)
+    }
+}
+
+/// Build the plain palette and, when `band_color` is set, its shaded twin.
+pub fn build_palettes(
+    col_formats: &[Option<Format>],
+    float_fmt: Option<&XlsxFormat>,
+    datetime_fmt: &XlsxFormat,
+    band_color: Option<&str>,
+) -> PyResult<(RowPalette, Option<RowPalette>)> {
+    let plain = RowPalette {
+        text: None,
+        float: float_fmt.cloned(),
+        datetime: datetime_fmt.clone(),
+        cols: col_formats.to_vec(),
+    };
+
+    let Some(color) = band_color else {
+        return Ok((plain, None));
+    };
+    let fill = parse_color(color)?;
+
+    let banded = RowPalette {
+        text: Some(XlsxFormat::new().set_background_color(fill)),
+        // A sheet with no float format still needs a shaded twin for its
+        // numeric cells, hence `unwrap_or_default` rather than `map`.
+        float: Some(
+            float_fmt
+                .cloned()
+                .unwrap_or_default()
+                .set_background_color(fill),
+        ),
+        datetime: datetime_fmt.clone().set_background_color(fill),
+        cols: col_formats
+            .iter()
+            .map(|c| {
+                c.as_ref().map(|f| Format {
+                    inner: f.inner.clone().set_background_color(fill),
+                })
+            })
+            .collect(),
+    };
+    Ok((plain, Some(banded)))
+}
+
 /// Borrow the inner `rust_xlsxwriter::Format` for column `idx`, if one was
 /// resolved. Used per-cell to let an explicit column format win over the
 /// sheet-wide float/datetime format.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -63,11 +63,172 @@ pub fn py_date_to_excel(d: &Bound<PyDate>) -> PyResult<ExcelDateTime> {
     })
 }
 
-/// Write a header cell at row 0, optionally bold, and mark the column
+/// Row-level layout for one sheet, resolved from Python before any cell is
+/// written.
+///
+/// Constant-memory mode flushes each row as soon as the next one starts and
+/// cannot revisit it — a `merge_range` or `set_row_height` aimed at a row that
+/// has already gone out is *silently* dropped (`rust_xlsxwriter` prints to
+/// stderr and carries on). So every one of these is applied up front, in
+/// [`SheetLayout::apply`], before the first data cell.
+#[derive(Default)]
+pub struct SheetLayout {
+    /// Row index the header is written on. Data starts at `header_row + 1`.
+    pub header_row: u32,
+    /// `(first_row, first_col, last_row, last_col, value, format)`.
+    pub merges: Vec<(u32, u16, u32, u16, String, Option<Format>)>,
+    pub row_heights: Vec<(u32, f64)>,
+    pub row_formats: Vec<(u32, Format)>,
+    /// Background colour for alternating data rows, as given by the caller.
+    pub band_color: Option<String>,
+}
+
+impl SheetLayout {
+    /// First data row.
+    pub fn first_data_row(&self) -> u32 {
+        self.header_row + 1
+    }
+
+    /// True when `row` (an absolute sheet row) is a shaded band row. The first
+    /// data row is left unshaded so banding starts on the second one.
+    pub fn is_banded(&self, row: u32) -> bool {
+        self.band_color.is_some() && (row - self.first_data_row()) % 2 == 1
+    }
+
+    /// Emit merges, row heights and row formats. Must run before data rows.
+    pub fn apply(&self, worksheet: &mut Worksheet) -> PyResult<()> {
+        for (r1, c1, r2, c2, value, fmt) in &self.merges {
+            let blank = Format::new();
+            worksheet
+                .merge_range(*r1, *c1, *r2, *c2, value, fmt.as_ref().unwrap_or(&blank))
+                .map_err(xlsx_err)?;
+        }
+        // Height before format: `set_row_format` on a row with no stored
+        // options would otherwise reset the height back to the default.
+        for (row, height) in &self.row_heights {
+            worksheet.set_row_height(*row, *height).map_err(xlsx_err)?;
+        }
+        for (row, fmt) in &self.row_formats {
+            worksheet.set_row_format(*row, fmt).map_err(xlsx_err)?;
+        }
+        Ok(())
+    }
+}
+
+fn value_err(msg: String) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyValueError, _>(msg)
+}
+
+/// Read a `{row_index: value}` mapping into a sorted `Vec<(u32, T)>`.
+fn row_keyed<T>(
+    spec: Option<&Bound<'_, PyAny>>,
+    what: &str,
+    mut convert: impl FnMut(&Bound<'_, PyAny>) -> PyResult<T>,
+) -> PyResult<Vec<(u32, T)>> {
+    let Some(spec) = spec else { return Ok(Vec::new()) };
+    let dict = spec.cast::<PyDict>().map_err(|_| {
+        value_err(format!("{what} must be a dict keyed by row index"))
+    })?;
+    let mut out = Vec::with_capacity(dict.len());
+    for (key, val) in dict.iter() {
+        let row: u32 = key.extract().map_err(|_| {
+            value_err(format!("{what}: row index must be a non-negative int"))
+        })?;
+        out.push((row, convert(&val)?));
+    }
+    out.sort_by_key(|(row, _)| *row);
+    Ok(out)
+}
+
+/// Build a [`SheetLayout`] from the Python-side arguments, rejecting anything
+/// constant-memory mode would otherwise drop without raising.
+pub fn resolve_layout(
+    header_row: u32,
+    merge_ranges: Option<&Bound<'_, PyAny>>,
+    row_heights: Option<&Bound<'_, PyAny>>,
+    row_formats: Option<&Bound<'_, PyAny>>,
+    banded_rows: Option<String>,
+) -> PyResult<SheetLayout> {
+    let mut merges = Vec::new();
+    if let Some(spec) = merge_ranges {
+        let list = spec.cast::<PyList>().map_err(|_| {
+            value_err("merge_ranges must be a list of (first_row, first_col, last_row, last_col, value[, format]) tuples".into())
+        })?;
+        for item in list.iter() {
+            let parts: Vec<Bound<'_, PyAny>> = item.extract().map_err(|_| {
+                value_err("each merge range must be a tuple/list of 5 or 6 items".into())
+            })?;
+            if parts.len() < 5 || parts.len() > 6 {
+                return Err(value_err(format!(
+                    "each merge range needs 5 or 6 items (first_row, first_col, last_row, last_col, value[, format]), got {}",
+                    parts.len()
+                )));
+            }
+            let r1: u32 = parts[0].extract()?;
+            let c1: u16 = parts[1].extract()?;
+            let r2: u32 = parts[2].extract()?;
+            let c2: u16 = parts[3].extract()?;
+            if r2 < r1 || c2 < c1 {
+                return Err(value_err(format!(
+                    "merge range ({r1}, {c1}, {r2}, {c2}) is inverted: last_row/last_col must not precede first_row/first_col"
+                )));
+            }
+            // A merge can only be written before the rows it covers are
+            // flushed, and headers/data start at `header_row`.
+            if r2 >= header_row {
+                return Err(value_err(format!(
+                    "merge range ({r1}, {c1}, {r2}, {c2}) reaches row {r2}, but the header row is {header_row} and data follows it. \
+Merged ranges must sit strictly above the header row — raise header_row to at least {} to make room.",
+                    r2 + 1
+                )));
+            }
+            let value = parts[4].str()?.to_string();
+            let fmt = match parts.get(5) {
+                Some(f) if !f.is_none() => Some(
+                    f.extract::<crate::format::Format>()
+                        .map_err(|_| {
+                            value_err("merge range format must be a Format object".into())
+                        })?
+                        .inner,
+                ),
+                _ => None,
+            };
+            merges.push((r1, c1, r2, c2, value, fmt));
+        }
+    }
+
+    let heights = row_keyed(row_heights, "row_heights", |v| {
+        let h: f64 = v.extract().map_err(|_| {
+            value_err("row_heights values must be numbers".into())
+        })?;
+        if h < 0.0 {
+            return Err(value_err("row_heights values must not be negative".into()));
+        }
+        Ok(h)
+    })?;
+
+    let formats = row_keyed(row_formats, "row_formats", |v| {
+        Ok(v.extract::<crate::format::Format>()
+            .map_err(|_| value_err("row_formats values must be Format objects".into()))?
+            .inner)
+    })?;
+
+    Ok(SheetLayout {
+        header_row,
+        merges,
+        row_heights: heights,
+        row_formats: formats,
+        band_color: banded_rows,
+    })
+}
+
+/// Write a header cell on `row`, optionally bold, and mark the column
 /// as an index (bold) column if listed in `index_columns`.
 /// When `header_fmt` is `Some`, it wins over `bold_headers` for the cell itself.
+#[allow(clippy::too_many_arguments)]
 pub fn write_header(
     worksheet: &mut Worksheet,
+    row: u32,
     col: u16,
     header: &str,
     bold_headers: bool,
@@ -77,17 +238,17 @@ pub fn write_header(
 ) -> PyResult<()> {
     if let Some(fmt) = header_fmt {
         worksheet
-            .write_string_with_format(0, col, header, fmt)
+            .write_string_with_format(row, col, header, fmt)
             .map_err(xlsx_err)?;
         return Ok(());
     }
     if bold_headers {
         worksheet
-            .write_string_with_format(0, col, header, bold_fmt)
+            .write_string_with_format(row, col, header, bold_fmt)
             .map_err(xlsx_err)?;
     } else {
         worksheet
-            .write_string(0, col, header)
+            .write_string(row, col, header)
             .map_err(xlsx_err)?;
     }
     if let Some(cols) = index_columns {
@@ -98,9 +259,11 @@ pub fn write_header(
     Ok(())
 }
 
-/// Write every header cell for a sheet (row 0) via [`write_header`].
+/// Write every header cell for a sheet on `row` via [`write_header`].
+#[allow(clippy::too_many_arguments)]
 pub fn write_all_headers(
     worksheet: &mut Worksheet,
+    row: u32,
     headers: &[String],
     bold_headers: bool,
     bold_fmt: &Format,
@@ -110,6 +273,7 @@ pub fn write_all_headers(
     for (col, header) in headers.iter().enumerate() {
         write_header(
             worksheet,
+            row,
             col as u16,
             header,
             bold_headers,
@@ -130,7 +294,8 @@ pub fn write_num(
     float_fmt: Option<&Format>,
 ) -> PyResult<()> {
     if val.is_nan() || val.is_infinite() {
-        worksheet.write_string(row, col, "").map_err(xlsx_err)?;
+        // Keep the format on the blank so a banded row has no unshaded hole.
+        write_string_opt(worksheet, row, col, "", float_fmt)?;
     } else if let Some(fmt) = float_fmt {
         worksheet
             .write_number_with_format(row, col, val, fmt)
@@ -175,6 +340,43 @@ pub fn write_string_opt(
             .map_err(xlsx_err)?;
     } else {
         worksheet.write_string(row, col, val).map_err(xlsx_err)?;
+    }
+    Ok(())
+}
+
+/// Write a boolean cell, with an optional explicit format.
+pub fn write_bool_opt(
+    worksheet: &mut Worksheet,
+    row: u32,
+    col: u16,
+    val: bool,
+    fmt: Option<&Format>,
+) -> PyResult<()> {
+    if let Some(fmt) = fmt {
+        worksheet
+            .write_boolean_with_format(row, col, val, fmt)
+            .map_err(xlsx_err)?;
+    } else {
+        worksheet.write_boolean(row, col, val).map_err(xlsx_err)?;
+    }
+    Ok(())
+}
+
+/// Write a datetime cell, with an optional explicit format. `None` relies on
+/// the column format having been set already.
+pub fn write_datetime_opt(
+    worksheet: &mut Worksheet,
+    row: u32,
+    col: u16,
+    val: &ExcelDateTime,
+    fmt: Option<&Format>,
+) -> PyResult<()> {
+    if let Some(fmt) = fmt {
+        worksheet
+            .write_datetime_with_format(row, col, val, fmt)
+            .map_err(xlsx_err)?;
+    } else {
+        worksheet.write_datetime(row, col, val).map_err(xlsx_err)?;
     }
     Ok(())
 }

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -346,29 +346,32 @@ fn write_worksheet_content(
                     } else {
                         plain
                     };
+                    // Everything but `col`/`col_override` is fixed for the row,
+                    // so build the sink once and step it across the columns
+                    // rather than reassembling all nine fields per cell.
+                    let mut sink = ExcelCell {
+                        worksheet: &mut *worksheet,
+                        row: row_u32,
+                        col: 0,
+                        text_fmt: pal.text.as_ref(),
+                        float_fmt: pal.float.as_ref(),
+                        datetime_fmt: &pal.datetime,
+                        datetime_cols_set: &mut datetime_cols_set,
+                        col_override: None,
+                        per_cell_datetime: banding,
+                    };
+
                     // Iterate the dict directly (insertion order == header order)
                     // to avoid allocating a fresh `values()` list per row.
                     for (col, (_key, value)) in row_dict.iter().enumerate() {
-                        let col_u16 = col as u16;
                         let cached = col_types
                             .get(col)
                             .copied()
                             .unwrap_or(ColType::Unknown);
 
+                        sink.col = col as u16;
                         // Column format override: wins over float_fmt / datetime_fmt.
-                        let col_override = pal.col(col);
-
-                        let mut sink = ExcelCell {
-                            worksheet: &mut *worksheet,
-                            row: row_u32,
-                            col: col_u16,
-                            text_fmt: pal.text.as_ref(),
-                            float_fmt: pal.float.as_ref(),
-                            datetime_fmt: &pal.datetime,
-                            datetime_cols_set: &mut datetime_cols_set,
-                            col_override,
-                            per_cell_datetime: banding,
-                        };
+                        sink.col_override = pal.col(col);
 
                         if !try_cached(&value, cached, &mut sink)? {
                             let detected = classify_and_write(&value, &mut sink)?;

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 use crate::cell::{classify_and_write, try_cached, CellWriter};
 use crate::data_types::{FreezePanesConfig, WorksheetData};
 use crate::helpers::{
-    py_date_to_excel, py_datetime_to_excel, save_workbook, write_all_headers, write_num,
-    write_number_opt, ColType,
+    py_date_to_excel, py_datetime_to_excel, save_workbook, write_all_headers, write_bool_opt,
+    write_datetime_opt, write_num, write_number_opt, write_string_opt, ColType,
 };
 use crate::utils::ensure_valid_sheet_name;
 
@@ -26,10 +26,17 @@ struct ExcelCell<'a> {
     worksheet: &'a mut rust_xlsxwriter::Worksheet,
     row: u32,
     col: u16,
+    /// Format for cells that otherwise carry none (strings, bools, blanks).
+    /// Only set on banded rows.
+    text_fmt: Option<&'a Format>,
     float_fmt: Option<&'a Format>,
     datetime_fmt: &'a Format,
     datetime_cols_set: &'a mut HashSet<u16>,
     col_override: Option<&'a Format>,
+    /// When banding is on, datetimes are formatted per cell instead of via a
+    /// one-shot column format — a column format is fixed for every row and so
+    /// cannot alternate.
+    per_cell_datetime: bool,
 }
 
 impl ExcelCell<'_> {
@@ -43,27 +50,57 @@ impl ExcelCell<'_> {
         }
         Ok(())
     }
+
+    fn put_datetime(&mut self, excel_dt: &rust_xlsxwriter::ExcelDateTime) -> PyResult<()> {
+        if self.per_cell_datetime {
+            let fmt = self.col_override.unwrap_or(self.datetime_fmt);
+            self.worksheet
+                .write_datetime_with_format(self.row, self.col, excel_dt, fmt)
+                .map_err(xlsx_err)?;
+        } else {
+            self.ensure_datetime_format()?;
+            self.worksheet
+                .write_datetime(self.row, self.col, excel_dt)
+                .map_err(xlsx_err)?;
+        }
+        Ok(())
+    }
+
+    fn put_string(&mut self, s: &str) -> PyResult<()> {
+        match self.text_fmt {
+            Some(fmt) => self
+                .worksheet
+                .write_string_with_format(self.row, self.col, s, fmt)
+                .map_err(xlsx_err)?,
+            None => self
+                .worksheet
+                .write_string(self.row, self.col, s)
+                .map_err(xlsx_err)?,
+        };
+        Ok(())
+    }
 }
 
 impl CellWriter for ExcelCell<'_> {
     fn write_none(&mut self) -> PyResult<()> {
-        self.worksheet
-            .write_string(self.row, self.col, "")
-            .map_err(xlsx_err)?;
-        Ok(())
+        self.put_string("")
     }
 
     fn write_str(&mut self, s: &str) -> PyResult<()> {
-        self.worksheet
-            .write_string(self.row, self.col, s)
-            .map_err(xlsx_err)?;
-        Ok(())
+        self.put_string(s)
     }
 
     fn write_bool(&mut self, b: bool) -> PyResult<()> {
-        self.worksheet
-            .write_boolean(self.row, self.col, b)
-            .map_err(xlsx_err)?;
+        match self.text_fmt {
+            Some(fmt) => self
+                .worksheet
+                .write_boolean_with_format(self.row, self.col, b, fmt)
+                .map_err(xlsx_err)?,
+            None => self
+                .worksheet
+                .write_boolean(self.row, self.col, b)
+                .map_err(xlsx_err)?,
+        };
         Ok(())
     }
 
@@ -79,25 +116,25 @@ impl CellWriter for ExcelCell<'_> {
 
     fn write_int(&mut self, i: &Bound<'_, PyInt>) -> PyResult<()> {
         let val: f64 = i.extract()?;
-        write_number_opt(self.worksheet, self.row, self.col, val, self.col_override)
+        // On a band row `text_fmt` carries the fill, so an unformatted integer
+        // column still gets shaded.
+        write_number_opt(
+            self.worksheet,
+            self.row,
+            self.col,
+            val,
+            self.col_override.or(self.text_fmt),
+        )
     }
 
     fn write_datetime(&mut self, dt: &Bound<'_, PyDateTime>) -> PyResult<()> {
-        self.ensure_datetime_format()?;
         let excel_dt = py_datetime_to_excel(dt)?;
-        self.worksheet
-            .write_datetime(self.row, self.col, &excel_dt)
-            .map_err(xlsx_err)?;
-        Ok(())
+        self.put_datetime(&excel_dt)
     }
 
     fn write_date(&mut self, d: &Bound<'_, PyDate>) -> PyResult<()> {
-        self.ensure_datetime_format()?;
         let excel_dt = py_date_to_excel(d)?;
-        self.worksheet
-            .write_datetime(self.row, self.col, &excel_dt)
-            .map_err(xlsx_err)?;
-        Ok(())
+        self.put_datetime(&excel_dt)
     }
 }
 
@@ -149,6 +186,7 @@ fn write_worksheet_content(
     column_widths: Option<&Bound<'_, PyAny>>,
     column_formats: Option<&Bound<'_, PyAny>>,
     header_format: Option<&crate::format::Format>,
+    layout: &crate::helpers::SheetLayout,
     py: Python,
 ) -> PyResult<()> {
     let float_fmt = float_format.map(|s| Format::new().set_num_format(s));
@@ -159,6 +197,12 @@ fn write_worksheet_content(
     let bold_fmt = Format::new().set_bold();
     let mut datetime_cols_set: HashSet<u16> = HashSet::new();
     let mut final_headers: Vec<String> = Vec::new();
+
+    // Merges, row heights and row formats must all land before the first data
+    // cell — constant-memory mode cannot revisit a flushed row.
+    layout.apply(worksheet)?;
+    let header_row = layout.header_row;
+    let banding = layout.band_color.is_some();
 
     match records {
         WorksheetData::ArrowDataFrame(stream_obj) => {
@@ -173,6 +217,7 @@ fn write_worksheet_content(
                     .collect();
                 write_all_headers(
                     worksheet,
+                    header_row,
                     &final_headers,
                     bold_headers,
                     &bold_fmt,
@@ -180,7 +225,7 @@ fn write_worksheet_content(
                     header_format.map(|h| &h.inner),
                 )?;
 
-                let mut current_row: u32 = 1;
+                let mut current_row: u32 = layout.first_data_row();
                 let mut formats_set = false;
 
                 // Resolve per-column formats ONCE (after headers are known).
@@ -188,6 +233,12 @@ fn write_worksheet_content(
                 // column formats to be set before their data rows.
                 let col_formats: Vec<Option<crate::format::Format>> =
                     crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
+                let (plain, banded) = crate::format::build_palettes(
+                    &col_formats,
+                    float_fmt.as_ref(),
+                    &datetime_fmt,
+                    layout.band_color.as_deref(),
+                )?;
 
                 for batch_result in reader {
                     let batch = batch_result.map_err(crate::arrow_ffi::batch_read_err)?;
@@ -208,8 +259,9 @@ fn write_worksheet_content(
                         worksheet,
                         &batch,
                         current_row,
-                        float_fmt.as_ref(),
-                        &col_formats,
+                        &plain,
+                        banded.as_ref(),
+                        layout,
                     )?;
 
                     current_row += batch.num_rows() as u32;
@@ -224,6 +276,7 @@ fn write_worksheet_content(
                     final_headers = cols.extract(py).unwrap_or_default();
                     write_all_headers(
                         worksheet,
+                        header_row,
                         &final_headers,
                         bold_headers,
                         &bold_fmt,
@@ -241,7 +294,11 @@ fn write_worksheet_content(
                 let mut col_types: Vec<ColType> = Vec::new();
                 // Resolved once when headers are first seen; kept alive for the
                 // entire row loop so we can hand out &Format borrows per cell.
-                let mut col_formats: Vec<Option<crate::format::Format>> = Vec::new();
+                // `banded` is None unless the sheet asked for alternating rows.
+                let mut palettes: Option<(
+                    crate::format::RowPalette,
+                    Option<crate::format::RowPalette>,
+                )> = None;
 
                 for (row_idx, row_res) in rows.enumerate() {
                     let row_obj = row_res?;
@@ -257,6 +314,7 @@ fn write_worksheet_content(
                         }
                         write_all_headers(
                             worksheet,
+                            header_row,
                             &headers,
                             bold_headers,
                             &bold_fmt,
@@ -267,13 +325,27 @@ fn write_worksheet_content(
                         final_headers = headers.clone();
                         // Resolve per-column formats ONCE and keep them for the whole loop.
                         // Apply set_column_format BEFORE writing data rows (constant memory mode).
-                        col_formats =
+                        let col_formats =
                             crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
                         crate::format::apply_column_formats(worksheet, &col_formats)?;
+                        palettes = Some(crate::format::build_palettes(
+                            &col_formats,
+                            float_fmt.as_ref(),
+                            &datetime_fmt,
+                            layout.band_color.as_deref(),
+                        )?);
                         headers_written = true;
                     }
 
-                    let row_u32 = (row_idx + 1) as u32;
+                    let row_u32 = layout.first_data_row() + row_idx as u32;
+                    let (plain, banded) = palettes
+                        .as_ref()
+                        .expect("palettes are built with the header row");
+                    let pal = if layout.is_banded(row_u32) {
+                        banded.as_ref().unwrap_or(plain)
+                    } else {
+                        plain
+                    };
                     // Iterate the dict directly (insertion order == header order)
                     // to avoid allocating a fresh `values()` list per row.
                     for (col, (_key, value)) in row_dict.iter().enumerate() {
@@ -284,16 +356,18 @@ fn write_worksheet_content(
                             .unwrap_or(ColType::Unknown);
 
                         // Column format override: wins over float_fmt / datetime_fmt.
-                        let col_override = crate::format::col_override(&col_formats, col);
+                        let col_override = pal.col(col);
 
                         let mut sink = ExcelCell {
                             worksheet: &mut *worksheet,
                             row: row_u32,
                             col: col_u16,
-                            float_fmt: float_fmt.as_ref(),
-                            datetime_fmt: &datetime_fmt,
+                            text_fmt: pal.text.as_ref(),
+                            float_fmt: pal.float.as_ref(),
+                            datetime_fmt: &pal.datetime,
                             datetime_cols_set: &mut datetime_cols_set,
                             col_override,
+                            per_cell_datetime: banding,
                         };
 
                         if !try_cached(&value, cached, &mut sink)? {
@@ -321,6 +395,7 @@ fn write_worksheet_content(
                 &bold_fmt,
                 index_columns,
                 header_format,
+                layout,
                 "__getitem__",
                 "tolist",
                 |dtype| {
@@ -344,6 +419,7 @@ fn write_worksheet_content(
                 &bold_fmt,
                 index_columns,
                 header_format,
+                layout,
                 "get_column",
                 "to_list",
                 |dtype| Ok(polars_kind(&dtype.to_string())),
@@ -417,10 +493,10 @@ fn write_df_rows<F>(
     nrows: usize,
     col_lists: &[Py<PyAny>],
     kind_at: F,
-    float_fmt: Option<&Format>,
-    datetime_fmt: &Format,
     datetime_cols_set: &mut HashSet<u16>,
-    col_formats: &[Option<crate::format::Format>],
+    plain: &crate::format::RowPalette,
+    banded: Option<&crate::format::RowPalette>,
+    layout: &crate::helpers::SheetLayout,
 ) -> PyResult<()>
 where
     F: Fn(usize) -> ScalarKind,
@@ -436,54 +512,80 @@ where
         })
         .collect();
 
-    // Per-column format override is fixed for the whole column — resolve once
-    // instead of per cell.
-    let col_overrides: Vec<Option<&Format>> = (0..bound_cols.len())
-        .map(|c| crate::format::col_override(col_formats, c))
-        .collect();
+    // Per-column format override is fixed for the whole column *within a
+    // palette* — resolve both variants once instead of per cell.
+    let plain_cols: Vec<Option<&Format>> =
+        (0..bound_cols.len()).map(|c| plain.col(c)).collect();
+    let banded_cols: Vec<Option<&Format>> = match banded {
+        Some(b) => (0..bound_cols.len()).map(|c| b.col(c)).collect(),
+        None => Vec::new(),
+    };
+    let banding = layout.band_color.is_some();
 
     for row in 0..nrows {
-        let row_u32 = (row + 1) as u32;
+        let row_u32 = layout.first_data_row() + row as u32;
+        let use_band = layout.is_banded(row_u32);
+        let pal = if use_band { banded.unwrap_or(plain) } else { plain };
+        let overrides = if use_band && banded.is_some() {
+            &banded_cols
+        } else {
+            &plain_cols
+        };
+        let text_fmt = pal.text.as_ref();
+
         for (col_idx, col_list) in bound_cols.iter().enumerate() {
             let col_u16 = col_idx as u16;
             let item = col_list.get(row)?;
-            let col_override = col_overrides[col_idx];
+            let col_override = overrides[col_idx];
 
             if item.is_none() {
-                worksheet.write_string(row_u32, col_u16, "").map_err(xlsx_err)?;
+                write_string_opt(worksheet, row_u32, col_u16, "", text_fmt)?;
                 continue;
             }
 
             match kind_at(col_idx) {
                 ScalarKind::Int => {
                     let val: f64 = item.extract()?;
-                    write_number_opt(worksheet, row_u32, col_u16, val, col_override)?;
+                    write_number_opt(
+                        worksheet,
+                        row_u32,
+                        col_u16,
+                        val,
+                        col_override.or(text_fmt),
+                    )?;
                 }
                 ScalarKind::Float => {
                     let val: f64 = item.extract()?;
-                    write_num(worksheet, row_u32, col_u16, val, col_override.or(float_fmt))?;
+                    write_num(
+                        worksheet,
+                        row_u32,
+                        col_u16,
+                        val,
+                        col_override.or(pal.float.as_ref()),
+                    )?;
                 }
                 ScalarKind::Bool => {
                     let val: bool = item.extract()?;
-                    worksheet
-                        .write_boolean(row_u32, col_u16, val)
-                        .map_err(xlsx_err)?;
+                    write_bool_opt(worksheet, row_u32, col_u16, val, text_fmt)?;
                 }
                 ScalarKind::Temporal => {
+                    // With banding the shade has to ride on the cell, since a
+                    // column format cannot alternate between rows.
+                    let dt_fmt = banding.then(|| col_override.unwrap_or(&pal.datetime));
                     if let Ok(dt) = item.cast::<PyDateTime>() {
                         let excel_dt = py_datetime_to_excel(&dt)?;
-                        worksheet
-                            .write_datetime(row_u32, col_u16, &excel_dt)
-                            .map_err(xlsx_err)?;
+                        write_datetime_opt(worksheet, row_u32, col_u16, &excel_dt, dt_fmt)?;
                     } else if let Ok(d) = item.cast::<PyDate>() {
                         let excel_dt = py_date_to_excel(&d)?;
-                        worksheet
-                            .write_datetime(row_u32, col_u16, &excel_dt)
-                            .map_err(xlsx_err)?;
+                        write_datetime_opt(worksheet, row_u32, col_u16, &excel_dt, dt_fmt)?;
                     } else {
-                        worksheet
-                            .write_string(row_u32, col_u16, item.to_string())
-                            .map_err(xlsx_err)?;
+                        write_string_opt(
+                            worksheet,
+                            row_u32,
+                            col_u16,
+                            &item.to_string(),
+                            text_fmt,
+                        )?;
                     }
                 }
                 ScalarKind::Other => {
@@ -491,10 +593,12 @@ where
                         worksheet: &mut *worksheet,
                         row: row_u32,
                         col: col_u16,
-                        float_fmt,
-                        datetime_fmt,
+                        text_fmt,
+                        float_fmt: pal.float.as_ref(),
+                        datetime_fmt: &pal.datetime,
                         datetime_cols_set: &mut *datetime_cols_set,
                         col_override,
+                        per_cell_datetime: banding,
                     };
                     classify_and_write(&item, &mut sink)?;
                 }
@@ -526,6 +630,7 @@ fn write_dataframe<C>(
     bold_fmt: &Format,
     index_columns: Option<&Vec<String>>,
     header_format: Option<&crate::format::Format>,
+    layout: &crate::helpers::SheetLayout,
     get_column_method: &str,
     to_list_method: &str,
     classify_dtype: C,
@@ -541,6 +646,7 @@ where
 
     write_all_headers(
         worksheet,
+        layout.header_row,
         &headers,
         bold_headers,
         bold_fmt,
@@ -576,6 +682,12 @@ where
     let col_formats: Vec<Option<crate::format::Format>> =
         crate::format::resolve_column_formats(column_formats, final_headers, py)?;
     crate::format::apply_column_formats(worksheet, &col_formats)?;
+    let (plain, banded) = crate::format::build_palettes(
+        &col_formats,
+        float_fmt,
+        datetime_fmt,
+        layout.band_color.as_deref(),
+    )?;
 
     write_df_rows(
         worksheet,
@@ -583,10 +695,10 @@ where
         nrows,
         &col_lists,
         |col_idx| col_kinds[col_idx],
-        float_fmt,
-        datetime_fmt,
         datetime_cols_set,
-        &col_formats,
+        &plain,
+        banded.as_ref(),
+        layout,
     )
 }
 
@@ -605,7 +717,7 @@ fn keyed_get<'py>(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None))]
+#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None))]
 pub fn write_worksheets(
     py: Python,
     records_with_sheet_name: Vec<(String, WorksheetData)>,
@@ -622,6 +734,11 @@ pub fn write_worksheets(
     column_formats: Option<Bound<'_, pyo3::types::PyDict>>,
     header_format: Option<Bound<'_, pyo3::types::PyDict>>,
     dedupe_strings: Option<Bound<'_, pyo3::types::PyDict>>,
+    header_row: Option<Bound<'_, pyo3::types::PyDict>>,
+    merge_ranges: Option<Bound<'_, pyo3::types::PyDict>>,
+    row_heights: Option<Bound<'_, pyo3::types::PyDict>>,
+    row_formats: Option<Bound<'_, pyo3::types::PyDict>>,
+    banded_rows: Option<Bound<'_, pyo3::types::PyDict>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     for (sheet_name, records) in records_with_sheet_name {
@@ -658,6 +775,22 @@ pub fn write_worksheets(
                 None => None,
             };
 
+        let sheet_header_row: u32 = keyed_get(header_row.as_ref(), &sheet_name)?
+            .map(|v| v.extract())
+            .transpose()?
+            .unwrap_or(0);
+        let sheet_band: Option<String> = keyed_get(banded_rows.as_ref(), &sheet_name)?
+            .filter(|v| !v.is_none())
+            .map(|v| v.extract())
+            .transpose()?;
+        let layout = crate::helpers::resolve_layout(
+            sheet_header_row,
+            keyed_get(merge_ranges.as_ref(), &sheet_name)?.as_ref(),
+            keyed_get(row_heights.as_ref(), &sheet_name)?.as_ref(),
+            keyed_get(row_formats.as_ref(), &sheet_name)?.as_ref(),
+            sheet_band,
+        )?;
+
         write_worksheet_content(
             &mut worksheet,
             &records,
@@ -673,6 +806,7 @@ pub fn write_worksheets(
             sheet_spec.as_ref(),
             sheet_col_fmts.as_ref(),
             sheet_hdr_fmt.as_ref(),
+            &layout,
             py,
         )?;
     }
@@ -683,7 +817,7 @@ pub fn write_worksheets(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false))]
+#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None))]
 pub fn write_worksheet(
     py: Python,
     records: WorksheetData,
@@ -702,7 +836,19 @@ pub fn write_worksheet(
     column_formats: Option<Bound<'_, PyAny>>,
     header_format: Option<Bound<'_, crate::format::Format>>,
     dedupe_strings: bool,
+    header_row: u32,
+    merge_ranges: Option<Bound<'_, PyAny>>,
+    row_heights: Option<Bound<'_, PyAny>>,
+    row_formats: Option<Bound<'_, PyAny>>,
+    banded_rows: Option<String>,
 ) -> PyResult<()> {
+    let layout = crate::helpers::resolve_layout(
+        header_row,
+        merge_ranges.as_ref(),
+        row_heights.as_ref(),
+        row_formats.as_ref(),
+        banded_rows,
+    )?;
     let mut workbook = Workbook::new();
     let mut worksheet = if dedupe_strings {
         workbook.add_worksheet()
@@ -733,6 +879,7 @@ pub fn write_worksheet(
         column_widths.as_ref(),
         column_formats.as_ref(),
         hdr_ref,
+        &layout,
         py,
     )?;
 

--- a/tests/test_row_layout.py
+++ b/tests/test_row_layout.py
@@ -1,0 +1,430 @@
+"""Merged cells, row heights, row formats and alternating row colours."""
+
+import datetime
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, Format, write_worksheet, write_worksheets
+
+BAND = "#F2F2F2"
+BAND_ARGB = "FFF2F2F2"
+NO_FILL = "00000000"
+
+
+def _records(n=6):
+    return [
+        {
+            "name": f"n{i}",
+            "score": i + 0.5,
+            "count": i,
+            "ok": i % 2 == 0,
+            "when": datetime.datetime(2026, 1, i + 1, 12, 0, 0),
+        }
+        for i in range(n)
+    ]
+
+
+def _fills(ws, row, ncols):
+    return [ws.cell(row=row, column=c).fill.fgColor.rgb for c in range(1, ncols + 1)]
+
+
+# --- merged cells ---------------------------------------------------------
+
+
+def test_merge_range_banner_above_header(tmp_path):
+    path = tmp_path / "crosstab.xlsx"
+    banner = Format().set_bold().set_align("center")
+    write_worksheet(
+        [{"region": "North", "male": 1, "female": 2}],
+        str(path),
+        sheet_name="X",
+        header_row=1,
+        merge_ranges=[(0, 1, 0, 2, "Gender", banner)],
+    )
+
+    ws = openpyxl.load_workbook(path)["X"]
+    assert [str(r) for r in ws.merged_cells.ranges] == ["B1:C1"]
+    assert ws["B1"].value == "Gender"
+    # Header pushed down to row 2 (1-based), data to row 3.
+    assert [c.value for c in ws[2]] == ["region", "male", "female"]
+    assert [c.value for c in ws[3]] == ["North", 1, 2]
+
+
+def test_merge_without_format_is_allowed(tmp_path):
+    path = tmp_path / "plain-merge.xlsx"
+    write_worksheet(
+        [{"a": 1}],
+        str(path),
+        header_row=1,
+        merge_ranges=[(0, 0, 0, 1, "Banner")],
+    )
+    ws = openpyxl.load_workbook(path).active
+    assert ws["A1"].value == "Banner"
+
+
+def test_merge_overlapping_header_raises(tmp_path):
+    """The silent-data-loss case: constant memory cannot merge a flushed row."""
+    with pytest.raises(ValueError, match="header row is 0"):
+        write_worksheet(
+            [{"a": 1}],
+            str(tmp_path / "bad.xlsx"),
+            merge_ranges=[(0, 0, 0, 1, "Banner")],
+        )
+
+
+def test_merge_reaching_data_rows_raises(tmp_path):
+    with pytest.raises(ValueError, match="raise header_row to at least 3"):
+        write_worksheet(
+            [{"a": 1}],
+            str(tmp_path / "bad.xlsx"),
+            header_row=1,
+            merge_ranges=[(0, 0, 2, 1, "Tall banner")],
+        )
+
+
+def test_inverted_merge_raises(tmp_path):
+    with pytest.raises(ValueError, match="inverted"):
+        write_worksheet(
+            [{"a": 1}],
+            str(tmp_path / "bad.xlsx"),
+            header_row=2,
+            merge_ranges=[(1, 0, 0, 1, "Backwards")],
+        )
+
+
+def test_merge_wrong_arity_raises(tmp_path):
+    with pytest.raises(ValueError, match="5 or 6 items"):
+        write_worksheet(
+            [{"a": 1}],
+            str(tmp_path / "bad.xlsx"),
+            header_row=1,
+            merge_ranges=[(0, 0, 0, 1)],
+        )
+
+
+# --- row heights and row formats -----------------------------------------
+
+
+def test_row_heights_and_row_formats(tmp_path):
+    path = tmp_path / "rows.xlsx"
+    write_worksheet(
+        _records(3),
+        str(path),
+        row_heights={0: 40.0, 2: 30.0},
+        row_formats={0: Format().set_border_bottom("thin")},
+    )
+
+    ws = openpyxl.load_workbook(path).active
+    assert ws.row_dimensions[1].height == pytest.approx(40.0, abs=0.5)
+    assert ws.row_dimensions[3].height == pytest.approx(30.0, abs=0.5)
+    assert ws["A1"].border.bottom.style == "thin"
+
+
+def test_row_height_survives_row_format_on_same_row(tmp_path):
+    """`set_row_format` resets a row's height unless the height lands first."""
+    path = tmp_path / "both.xlsx"
+    write_worksheet(
+        _records(2),
+        str(path),
+        row_heights={0: 44.0},
+        row_formats={0: Format().set_bold()},
+    )
+    ws = openpyxl.load_workbook(path).active
+    assert ws.row_dimensions[1].height == pytest.approx(44.0, abs=0.5)
+    assert ws["A1"].font.bold
+
+
+def test_negative_row_height_raises(tmp_path):
+    with pytest.raises(ValueError, match="must not be negative"):
+        write_worksheet([{"a": 1}], str(tmp_path / "bad.xlsx"), row_heights={0: -5})
+
+
+def test_row_formats_rejects_non_format(tmp_path):
+    with pytest.raises(ValueError, match="must be Format objects"):
+        write_worksheet([{"a": 1}], str(tmp_path / "bad.xlsx"), row_formats={0: "bold"})
+
+
+# --- banded rows ----------------------------------------------------------
+
+
+def test_banded_rows_shade_every_other_data_row(tmp_path):
+    path = tmp_path / "banded.xlsx"
+    write_worksheet(_records(4), str(path), banded_rows=BAND)
+
+    ws = openpyxl.load_workbook(path).active
+    assert _fills(ws, 1, 5) == [NO_FILL] * 5  # header untouched
+    assert _fills(ws, 2, 5) == [NO_FILL] * 5  # first data row unshaded
+    assert _fills(ws, 3, 5) == [BAND_ARGB] * 5
+    assert _fills(ws, 4, 5) == [NO_FILL] * 5
+    assert _fills(ws, 5, 5) == [BAND_ARGB] * 5
+
+
+def test_banding_covers_formatted_and_typed_cells(tmp_path):
+    """The regression this feature exists for.
+
+    A cell written with its own format ignores the row's, so banding done via
+    ``set_row_format`` leaves holes in exactly the columns that carry a number
+    format. Every column here has a different write path — float, int, bool,
+    datetime, string, plus an explicit column format.
+    """
+    path = tmp_path / "holes.xlsx"
+    write_worksheet(
+        _records(4),
+        str(path),
+        float_format="0.00",
+        banded_rows=BAND,
+        column_formats={"count": Format().set_num_format("#,##0")},
+    )
+
+    ws = openpyxl.load_workbook(path).active
+    for row in (3, 5):
+        assert _fills(ws, row, 5) == [BAND_ARGB] * 5, f"hole in row {row}"
+
+
+def test_banding_preserves_number_formats(tmp_path):
+    path = tmp_path / "fmt.xlsx"
+    write_worksheet(
+        _records(4),
+        str(path),
+        float_format="0.00",
+        banded_rows=BAND,
+        column_formats={"count": Format().set_num_format("#,##0")},
+    )
+    ws = openpyxl.load_workbook(path).active
+    # Column formats survive on both plain and banded rows.
+    for row in (2, 3):
+        assert ws.cell(row=row, column=2).number_format == "0.00"
+        assert ws.cell(row=row, column=3).number_format == "#,##0"
+
+
+def test_banding_preserves_values(tmp_path):
+    path = tmp_path / "vals.xlsx"
+    records = _records(4)
+    write_worksheet(records, str(path), banded_rows=BAND)
+
+    ws = openpyxl.load_workbook(path).active
+    for idx, rec in enumerate(records):
+        row = idx + 2
+        assert ws.cell(row=row, column=1).value == rec["name"]
+        assert ws.cell(row=row, column=2).value == pytest.approx(rec["score"])
+        assert ws.cell(row=row, column=3).value == rec["count"]
+        assert ws.cell(row=row, column=4).value == rec["ok"]
+        assert ws.cell(row=row, column=5).value == rec["when"]
+
+
+def test_banding_offset_by_header_row(tmp_path):
+    """Banding counts from the first data row, not from sheet row 0."""
+    path = tmp_path / "offset.xlsx"
+    write_worksheet(
+        _records(4),
+        str(path),
+        header_row=2,
+        merge_ranges=[(0, 0, 0, 1, "Banner")],
+        banded_rows=BAND,
+    )
+    ws = openpyxl.load_workbook(path).active
+    assert _fills(ws, 4, 5) == [NO_FILL] * 5  # first data row
+    assert _fills(ws, 5, 5) == [BAND_ARGB] * 5
+
+
+def test_bad_band_colour_raises(tmp_path):
+    with pytest.raises(ValueError):
+        write_worksheet([{"a": 1}], str(tmp_path / "bad.xlsx"), banded_rows="not-a-colour")
+
+
+# --- builder + multi-sheet ------------------------------------------------
+
+
+def test_fastexcel_row_layout(tmp_path):
+    path = tmp_path / "builder.xlsx"
+    (
+        FastExcel(str(path))
+        .sheet(
+            "Report",
+            _records(4),
+            header_row=1,
+            merge_ranges=[(0, 1, 0, 2, "Metrics")],
+            row_heights={1: 28.0},
+            row_formats={1: Format().set_border_bottom("thin")},
+            banded_rows=BAND,
+        )
+        .save()
+    )
+
+    ws = openpyxl.load_workbook(path)["Report"]
+    assert [str(r) for r in ws.merged_cells.ranges] == ["B1:C1"]
+    assert ws.row_dimensions[2].height == pytest.approx(28.0, abs=0.5)
+    assert ws["A2"].border.bottom.style == "thin"
+    assert _fills(ws, 4, 5) == [BAND_ARGB] * 5
+
+
+def test_multi_sheet_layout_is_per_sheet(tmp_path):
+    path = tmp_path / "multi.xlsx"
+    write_worksheets(
+        [("Banded", _records(4)), ("Plain", _records(4))],
+        str(path),
+        banded_rows={"Banded": BAND},
+    )
+
+    wb = openpyxl.load_workbook(path)
+    assert _fills(wb["Banded"], 3, 5) == [BAND_ARGB] * 5
+    assert _fills(wb["Plain"], 3, 5) == [NO_FILL] * 5
+
+
+def test_multi_sheet_general_key_applies_to_all(tmp_path):
+    path = tmp_path / "general.xlsx"
+    write_worksheets(
+        [("A", _records(4)), ("B", _records(4))],
+        str(path),
+        banded_rows={"general": BAND},
+    )
+    wb = openpyxl.load_workbook(path)
+    for name in ("A", "B"):
+        assert _fills(wb[name], 3, 5) == [BAND_ARGB] * 5
+
+
+def test_layout_defaults_unchanged(tmp_path):
+    """No layout arguments must leave output exactly as before."""
+    plain = tmp_path / "plain.xlsx"
+    write_worksheet(_records(4), str(plain))
+    ws = openpyxl.load_workbook(plain).active
+    assert [c.value for c in ws[1]] == ["name", "score", "count", "ok", "when"]
+    assert _fills(ws, 2, 5) == [NO_FILL] * 5
+    assert not ws.merged_cells.ranges
+
+
+# --- DataFrame paths ------------------------------------------------------
+# Records, Arrow, Pandas and Polars each write cells through a different code
+# path, so banding has to be asserted on all of them, not just Records.
+
+
+@pytest.mark.parametrize("frame", ["pandas", "polars"])
+def test_banding_on_dataframe_paths(tmp_path, frame):
+    mod = pytest.importorskip(frame)
+    data = {
+        "name": ["a", "b", "c", "d"],
+        "score": [1.5, 2.5, 3.5, 4.5],
+        "count": [1, 2, 3, 4],
+    }
+    df = mod.DataFrame(data)
+
+    path = tmp_path / f"{frame}.xlsx"
+    write_worksheet(df, str(path), float_format="0.00", banded_rows=BAND)
+
+    ws = openpyxl.load_workbook(path).active
+    assert [c.value for c in ws[1]] == ["name", "score", "count"]
+    assert _fills(ws, 2, 3) == [NO_FILL] * 3
+    assert _fills(ws, 3, 3) == [BAND_ARGB] * 3, f"{frame}: hole on banded row"
+    assert _fills(ws, 5, 3) == [BAND_ARGB] * 3
+    assert ws.cell(row=3, column=2).value == pytest.approx(2.5)
+
+
+@pytest.mark.parametrize("frame", ["pandas", "polars"])
+def test_header_row_offset_on_dataframe_paths(tmp_path, frame):
+    mod = pytest.importorskip(frame)
+    df = mod.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    path = tmp_path / f"{frame}-offset.xlsx"
+    write_worksheet(
+        df,
+        str(path),
+        header_row=1,
+        merge_ranges=[(0, 0, 0, 1, "Banner")],
+    )
+
+    ws = openpyxl.load_workbook(path).active
+    assert ws["A1"].value == "Banner"
+    assert [c.value for c in ws[2]] == ["a", "b"]
+    assert [c.value for c in ws[3]] == [1, 3]
+
+
+def test_banding_on_datetime_dataframe_column(tmp_path):
+    """Datetimes rely on a column format, which cannot alternate per row."""
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame(
+        {
+            "when": pd.to_datetime(
+                ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]
+            ),
+            "n": [1, 2, 3, 4],
+        }
+    )
+    path = tmp_path / "dt.xlsx"
+    write_worksheet(df, str(path), banded_rows=BAND)
+
+    ws = openpyxl.load_workbook(path).active
+    assert _fills(ws, 3, 2) == [BAND_ARGB] * 2
+    assert _fills(ws, 5, 2) == [BAND_ARGB] * 2
+    assert ws.cell(row=3, column=1).value == datetime.datetime(2026, 1, 2)
+    # The datetime number format must survive the banding.
+    assert "yyyy" in ws.cell(row=3, column=1).number_format
+
+
+class _FakeFrame:
+    """Pandas-shaped object without ``__arrow_c_stream__``.
+
+    Modern pandas and Polars both expose the Arrow stream, so the
+    ``write_dataframe`` fallback is unreachable through them. This stands in
+    for the old-pandas / exotic-dtype case that path actually exists for.
+    """
+
+    class _Dtype:
+        def __init__(self, kind):
+            self.kind = kind
+
+    class _Series:
+        def __init__(self, values):
+            self._values = values
+
+        def tolist(self):
+            return list(self._values)
+
+    def __init__(self, data, kinds):
+        self._data = data
+        self.columns = list(data)
+        self.dtypes = [self._Dtype(k) for k in kinds]
+
+    def __len__(self):
+        return len(next(iter(self._data.values())))
+
+    def __getitem__(self, key):
+        return self._Series(self._data[key])
+
+
+def test_banding_on_dataframe_fallback_path(tmp_path):
+    df = _FakeFrame(
+        {
+            "name": ["a", "b", "c", "d"],
+            "score": [1.5, 2.5, 3.5, 4.5],
+            "count": [1, 2, 3, 4],
+            "ok": [True, False, True, False],
+            "when": [datetime.datetime(2026, 1, d + 1) for d in range(4)],
+        },
+        kinds=["O", "f", "i", "b", "M"],
+    )
+
+    path = tmp_path / "fallback.xlsx"
+    write_worksheet(df, str(path), float_format="0.00", banded_rows=BAND)
+
+    ws = openpyxl.load_workbook(path).active
+    assert [c.value for c in ws[1]] == ["name", "score", "count", "ok", "when"]
+    assert _fills(ws, 2, 5) == [NO_FILL] * 5
+    assert _fills(ws, 3, 5) == [BAND_ARGB] * 5
+    assert _fills(ws, 5, 5) == [BAND_ARGB] * 5
+    assert ws.cell(row=3, column=1).value == "b"
+    assert ws.cell(row=3, column=2).value == pytest.approx(2.5)
+    assert ws.cell(row=3, column=4).value is False
+    assert ws.cell(row=3, column=5).value == datetime.datetime(2026, 1, 2)
+
+
+def test_header_row_offset_on_dataframe_fallback_path(tmp_path):
+    df = _FakeFrame({"a": [1, 2], "b": [3, 4]}, kinds=["i", "i"])
+    path = tmp_path / "fallback-offset.xlsx"
+    write_worksheet(
+        df, str(path), header_row=1, merge_ranges=[(0, 0, 0, 1, "Banner")]
+    )
+    ws = openpyxl.load_workbook(path).active
+    assert ws["A1"].value == "Banner"
+    assert [c.value for c in ws[2]] == ["a", "b"]
+    assert [c.value for c in ws[3]] == [1, 3]


### PR DESCRIPTION
Addresses items 2, 3, 4 and 5 of #20 — the three the reporter called most critical (merged cells, row-level borders, alt-row colour) plus row height, which shares the same mechanism.

Rebased onto `master` now that #54 has merged.

## API

```python
banner = Format().set_bold().set_align("center")
under_header = Format().set_border_bottom("thin")

(
    FastExcel("crosstab.xlsx")
    .sheet(
        "Survey",
        rows,
        header_row=1,                                    # leave row 0 for banners
        merge_ranges=[(0, 1, 0, 2, "Gender", banner)],   # "Gender" spans B:C
        row_heights={0: 28, 1: 22},
        row_formats={1: under_header},                   # rule under the header
        banded_rows="#F2F2F2",
    )
    .save()
)
```

`write_worksheets` takes each of these as a dict keyed by sheet name, with the usual `"general"` fallback.

## Two things worth reviewing

**Ordering is validated, not assumed.** Sheets are written row by row in constant-memory mode, and a flushed row cannot be revisited — `rust_xlsxwriter` drops a late `merge_range` with nothing but a line on stderr, producing a file that is silently missing its banner. A merge range reaching `header_row` or below now raises `ValueError` naming the `header_row` to use instead.

**Banding is per cell, not per row.** `set_row_format` looked like the obvious implementation, but a cell written with its own format ignores the row's. Measured on a sheet whose middle column had a number format:

```
row fills via set_row_format: ['FFF2F2F2', '00000000', 'FFF2F2F2']
                                            ^^^^^^^^ unshaded hole
```

So each cell on a band row gets an explicit format carrying the fill, built once per sheet as a twin of the plain one. Cells that previously wrote unformatted (blanks, strings, bools, datetimes) now take an optional format, and datetimes switch from a one-shot column format to a per-cell one when banding is on, since a column format cannot alternate between rows. `test_banding_covers_formatted_and_typed_cells` pins this.

## Not included

Hyperlinks (#20 item 6), conditional formatting and charts. Each needs its own API surface — hyperlinks touch the shared type cascade in `cell.rs`, conditional formatting needs rule classes. Better as separate PRs.

## Verification

```
cargo build --release            → OK
cargo clippy --release           → 14 warnings, same as base (none new)
pytest tests/ -m "not benchmark" → 186 passed (27 new)
```

Tests cover all four data paths. Pandas 3 and Polars both expose `__arrow_c_stream__` and so exercise the Arrow path; a `_FakeFrame` stub covers the `write_dataframe` fallback that would otherwise go untested.

The default path costs about **1.3%**. 200k rows, minimum of 15 runs, measured against `master`:

| | base | this PR | delta |
|---|---|---|---|
| records | 0.4571s | 0.4631s | +1.3% |
| records + `float_format` | 0.4950s | 0.5015s | +1.3% |
| records + `column_formats` | 0.5285s | 0.5352s | +1.3% |
| arrow/pandas | 0.3221s | 0.3246s | +0.8% |
| records + `bold_headers` | 0.4573s | 0.4634s | +1.3% |

It was +2.7% before `perf(excel): build the Records cell sink once per row` — `ExcelCell` grew two fields for banding and was being reassembled per cell, so it is now built once per row and stepped across the columns. The remaining 1.3% is per-cell: an extra `Option` check when writing integers and a branch on `text_fmt` when writing strings. Removing it would mean duplicating the inner loop per banding mode, which does not seem worth 1.3%.

### 1M rows, via `benchmark.py`

Using `benchmark.py`'s own generators and its `xlsxwriter` baseline writer, with the generated data cached so both branches get identical input (minimum of 3 runs):

| 1M rows | base | this PR | delta | xlsxwriter | speedup base | speedup PR |
|---|---|---|---|---|---|---|
| records | 6.598s | 6.672s | +1.1% | 52.1s | 7.89x | 7.80x |
| pandas | 2.676s | 2.688s | +0.5% | 20.1s | 7.50x | 7.47x |
| polars | 2.677s | 2.679s | +0.1% | 19.4s | 7.25x | 7.24x |

So the headline speedup moves by about 0.09x on the records path and is unchanged within noise on the DataFrame paths. The regression is smaller at 1M than at 200k (+1.1% vs +1.3%) because part of the added work is per-row and per-sheet rather than per-cell.

The README table is not updated: those numbers come from a different machine (base measures 7.89x here, not the 8.7x quoted), so overwriting them with these would be misleading. The `~7x-9x` claim still holds.

Banding itself costs ~20% (records 0.468s -> 0.561s), paid only when enabled.


