### PR TITLE
fix(csv): warn on discarded Excel options; unbreak dev install

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ xlsx_bytes = buf.getvalue()  # send as HTTP response
 ### CSV / TSV Output
 
 ```python
-# Auto-detected from file extension — same API, no code change
+# Auto-detected from file extension
 FastExcel("output.csv").sheet("Sheet1", records).save()
 FastExcel("output.tsv").sheet("Sheet1", records).save()
 
@@ -311,6 +311,20 @@ from rustpy_xlsxwriter import write_csv
 write_csv(records, "output.csv")
 write_csv(records, "output.csv", delimiter=";")  # custom delimiter
 ```
+
+CSV carries no formatting, so every Excel-only option is dropped —
+`float_format`, `column_formats`, `header_format`, freeze panes, merges,
+banding, row heights and formats, `password`, `dedupe_strings`. Only
+`delimiter` and `sanitize_formulas` apply. Switching a target from `.xlsx` to
+`.csv` therefore silently changes the output, so the builder warns and names
+what it discarded:
+
+```python
+FastExcel("out.csv").format(float_format="0.00").sheet("S", rows).save()
+# UserWarning: CSV/TSV output ignores Excel-only options: float_format. …
+```
+
+The data is still written correctly — only the styling is gone.
 
 ### Functional API
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pytest-codspeed==5.0.3
 python-dateutil==2.9.0.post0
 pytokens==0.4.1
 rich==15.0.0
--e git+ssh://git@github.com/rahmadafandi/rustpy-xlsxwriter.git@c42b28d5ad71d34ca02485693e1613dc48494f60#egg=rustpy_xlsxwriter
+-e .
 semantic-version==2.10.0
 setuptools==83.0.0
 setuptools-rust==1.13.0

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -64,6 +64,7 @@ from typing import (
 )
 
 import os as _os
+import warnings as _warnings
 from importlib.metadata import metadata as _metadata
 from importlib.metadata import version as _version
 
@@ -370,6 +371,32 @@ class FastExcel:
 
     # -- output -------------------------------------------------------------
 
+    def _excel_only_options(self) -> List[str]:
+        """Names of set options that only apply to ``.xlsx`` output.
+
+        ``autofit`` and ``sanitize_formulas`` are left out: the first is on by
+        default so it would fire on every CSV write, and the second is CSV-only.
+        """
+        configured = {
+            "password": self._password,
+            "float_format": self._float_format,
+            "datetime_format": self._datetime_format,
+            "index_columns": self._index_columns,
+            "bold_headers": self._bold_headers,
+            "freeze": self._freeze_panes,
+            "column_width": self._col_width,
+            "column_widths": self._col_widths,
+            "column_formats": self._col_formats,
+            "header_format": self._header_format,
+            "dedupe_strings": self._dedupe_strings,
+            "header_row": self._header_row,
+            "merge_ranges": self._merge_ranges,
+            "row_heights": self._row_heights,
+            "row_formats": self._row_formats,
+            "banded_rows": self._banded_rows,
+        }
+        return [name for name, value in configured.items() if value]
+
     def save(self) -> None:
         """Write all sheets to the target file or buffer.
 
@@ -395,6 +422,15 @@ class FastExcel:
                     )
                 delimiter = "\t" if lower.endswith(".tsv") else ","
                 _, data = self._sheets[0]
+                ignored = self._excel_only_options()
+                if ignored:
+                    _warnings.warn(
+                        "CSV/TSV output ignores Excel-only options: "
+                        f"{', '.join(ignored)}. "
+                        "The file will contain unformatted values; write to "
+                        "'.xlsx' if you need them.",
+                        stacklevel=2,
+                    )
                 write_csv(
                     data,
                     self._target,

--- a/tests/test_csv_ignored_options.py
+++ b/tests/test_csv_ignored_options.py
@@ -1,0 +1,130 @@
+"""CSV/TSV output must say what it is throwing away.
+
+Every Excel-only option is silently discarded on the CSV path — the Rust
+``write_csv`` only takes a delimiter and the formula guard. Swapping a target
+from ``.xlsx`` to ``.csv`` therefore drops all formatting, so the builder warns
+instead of quietly producing a plain file.
+"""
+
+import contextlib
+import warnings
+
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, Format
+
+ROWS = [{"a": 1.23456, "b": "x"}]
+
+
+@contextlib.contextmanager
+def _no_warnings():
+    """Assert nothing warns (``pytest.warns(None)`` is an error in pytest 8+)."""
+    with warnings.catch_warnings(record=True) as log:
+        warnings.simplefilter("always")
+        yield
+    assert not log, f"unexpected warnings: {[str(x.message) for x in log]}"
+
+
+def test_no_warning_when_nothing_excel_only_is_set(tmp_path):
+    path = tmp_path / "plain.csv"
+    with _no_warnings():
+        FastExcel(str(path)).sheet("S", ROWS).save()
+    assert path.read_text().strip() == "a,b\n1.23456,x"
+
+
+def test_autofit_alone_does_not_warn(tmp_path):
+    """autofit defaults to True, so warning on it would fire on every CSV."""
+    with _no_warnings():
+        FastExcel(str(tmp_path / "a.csv"), autofit=True).sheet("S", ROWS).save()
+
+
+def test_sanitize_formulas_does_not_warn(tmp_path):
+    """It is a CSV-only option, not an ignored one."""
+    with _no_warnings():
+        FastExcel(str(tmp_path / "s.csv"), sanitize_formulas=True).sheet(
+            "S", ROWS
+        ).save()
+
+
+def test_warns_and_names_the_ignored_options(tmp_path):
+    path = tmp_path / "fmt.csv"
+    with pytest.warns(UserWarning) as rec:
+        (
+            FastExcel(str(path), password="s3cret")
+            .format(float_format="0.00", bold_headers=True)
+            .freeze(row=1)
+            .sheet("S", ROWS, column_widths={"a": 20}, banded_rows="#EEEEEE")
+            .save()
+        )
+
+    message = str(rec[0].message)
+    for name in (
+        "password",
+        "float_format",
+        "bold_headers",
+        "freeze",
+        "column_widths",
+        "banded_rows",
+    ):
+        assert name in message, f"{name} missing from warning"
+    # The data is still written correctly, unformatted.
+    assert path.read_text().strip() == "a,b\n1.23456,x"
+
+
+@pytest.mark.parametrize(
+    "configure",
+    [
+        pytest.param(lambda f, rows: f.sheet("S", rows, header_row=1), id="header_row"),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, row_heights={0: 20}), id="row_heights"
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, row_formats={0: Format().set_bold()}),
+            id="row_formats",
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, dedupe_strings=True), id="dedupe_strings"
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, header_format=Format().set_bold()),
+            id="header_format",
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, column_formats={"a": Format()}),
+            id="column_formats",
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, column_width=15.0), id="column_width"
+        ),
+        pytest.param(
+            lambda f, rows: f.format(datetime_format="yyyy").sheet("S", rows),
+            id="datetime_format",
+        ),
+        pytest.param(
+            lambda f, rows: f.format(index_columns=["a"]).sheet("S", rows),
+            id="index_columns",
+        ),
+    ],
+)
+def test_each_excel_only_option_warns(tmp_path, configure):
+    """Guards against a new option being added without joining the warning."""
+    f = FastExcel(str(tmp_path / "each.csv"))
+    with pytest.warns(UserWarning, match="ignores Excel-only options"):
+        configure(f, ROWS).save()
+
+
+def test_tsv_warns_too(tmp_path):
+    with pytest.warns(UserWarning, match="ignores Excel-only options"):
+        FastExcel(str(tmp_path / "o.tsv")).format(float_format="0.00").sheet(
+            "S", ROWS
+        ).save()
+
+
+def test_xlsx_never_warns(tmp_path):
+    with _no_warnings():
+        (
+            FastExcel(str(tmp_path / "o.xlsx"), password="s3cret")
+            .format(float_format="0.00")
+            .sheet("S", ROWS, banded_rows="#EEEEEE")
+            .save()
+        )


### PR DESCRIPTION
Two small fixes found while auditing the wrapper for rough edges.

## 1. CSV silently discarded every Excel option

Writing to `.csv`/`.tsv` dropped `float_format`, `datetime_format`, `index_columns`, `bold_headers`, `password`, freeze panes, column widths and formats, `header_format`, `dedupe_strings`, `header_row`, `merge_ranges`, `row_heights`, `row_formats` and `banded_rows` — with no signal whatsoever. Confirmed before the fix:

```python
FastExcel("o.csv", password="x").format(float_format="0.00") \
    .sheet("S", [{"a": 1.23456}], banded_rows="#EEE").save()
# warnings: NONE
# o.csv: a
#        1.23456      <- float_format ignored too
```

The README made it worse by advertising the CSV path as *"same API, no code change"*. Someone switching a target from `.xlsx` to `.csv` lost all formatting and had no way to notice.

The builder now names what it threw away:

```
UserWarning: CSV/TSV output ignores Excel-only options: password, float_format,
banded_rows. The file will contain unformatted values; write to '.xlsx' if you
need them.
```

`autofit` and `sanitize_formulas` are deliberately excluded — the first defaults to `True` so it would fire on every CSV write, the second is CSV-only. The data itself is unchanged; only the warning is new.

The test is parametrised over each option individually, so a future option that forgets to join the warning fails there rather than going quiet.

## 2. Dev requirements could not be installed

`requirements.txt` line 32 pinned the package to itself:

```
-e git+ssh://git@github.com/rahmadafandi/rustpy-xlsxwriter.git@c42b28d…#egg=rustpy_xlsxwriter
```

`c42b28d` is v0.4.2 — two minor versions stale. Anyone without SSH access to the repo could not run `pip install -r requirements.txt` at all, and anyone with access silently got an old build to test against. Replaced with `-e .`.

Verified in a clean venv from the repo root:

```
pip install -r requirements.txt   → builds the extension, ~50s
get_version()                     → 0.6.1   (was 0.4.2)
pytest -m "not benchmark"         → 201 passed
```

Note `-e .` resolves against the working directory, which is standard pip behaviour for requirements files — run it from the repo root, as the docs already assume.

## Verification

```
pytest tests/ -m "not benchmark" → 201 passed (15 new)
clean-venv install               → 0.6.1, 201 passed
```
