### PR TITLE
fix(csv): warn on discarded options, unbreak dev install; add autofilter, hyperlinks, totals row, formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ under_header = Format().set_border_bottom("thin")
 | `row_heights` | `{row_index: height}` in points |
 | `row_formats` | `{row_index: Format}` — borders under headers, above totals |
 | `banded_rows` | Background colour for every other data row |
+| `autofilter` | Filter dropdowns over the header row and its data |
+
+`autofilter=True` sizes its own range from the rows actually written, so it
+follows `header_row` and needs no manual bounds:
+
+```python
+FastExcel("report.xlsx").sheet("Data", rows, autofilter=True, freeze_row=1).save()
+```
 
 **Ordering is enforced, not assumed.** Sheets are written row by row and a row
 that has been flushed cannot be revisited — `rust_xlsxwriter` would drop a late

--- a/README.md
+++ b/README.md
@@ -263,10 +263,13 @@ into the data.
 `totals_format` exists because the totals row index depends on how much data
 there was, so `row_formats` cannot reach it.
 
-> **The formulas carry no computed result.** Readers that use cached values —
-> `pandas.read_excel`, `openpyxl` with `data_only=True` — see `0` until Excel or
-> LibreOffice opens the file and recalculates. Use the totals row for files
-> people will open, not for a machine-readable handoff.
+> **The formulas carry no computed result.** This library does not evaluate
+> them; Excel and LibreOffice do, on open. Readers that trust the cached value —
+> `pandas.read_excel`, `openpyxl` with `data_only=True` — get `None`, not a
+> number. That is deliberate: the cached result is written empty rather than
+> left at the underlying crate's default of `0`, which would look like a real
+> total of zero. Use the totals row for files people will open, not for a
+> machine-readable handoff.
 
 ### Hyperlinks
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ under_header = Format().set_border_bottom("thin")
 
 | `url_columns` | Column names whose text cells become clickable links |
 | `totals_row` | Aggregate formulas in a row below the data |
+| `formula_columns` | Computed columns appended after the data |
 
 `autofilter=True` sizes its own range from the rows actually written, so it
 follows `header_row` and needs no manual bounds:
@@ -233,6 +234,51 @@ follows `header_row` and needs no manual bounds:
 ```python
 FastExcel("report.xlsx").sheet("Data", rows, autofilter=True, freeze_row=1).save()
 ```
+
+### Formulas
+
+Append computed columns. `{row}` becomes that row's sheet row, `{first}` the
+first data row:
+
+```python
+(
+    FastExcel("report.xlsx")
+    .sheet(
+        "Sales",
+        rows,
+        formula_columns={
+            "total":   "=A{row}*B{row}",
+            "running": "=SUM(B${first}:B{row})",
+        },
+    )
+    .save()
+)
+```
+
+The text goes to Excel unchanged, so **anything Excel accepts works** — nested
+calls, `SUMIFS`, `INDEX`/`MATCH`, cross-sheet references. Modern functions are
+handled for you: the 131 "future" functions (`IFS`, `TEXTJOIN`, `MAXIFS`,
+`STDEV.P`, …) get their required `_xlfn.` prefix, and the 30 dynamic-array ones
+(`XLOOKUP`, `UNIQUE`, `SORT`, `FILTER`, …) additionally get array-formula markup
+and the `xl/metadata.xml` part. Writing those by hand is the usual way to end up
+with a file Excel refuses to open.
+
+`totals_row` values may also be raw formulas — a value starting with `=`, with
+`{col}` the column letter and `{first}`/`{last}` the data range:
+
+```python
+totals_row={"qty": "sum", "price": "=ROUND(AVERAGE({col}{first}:{col}{last}),2)"}
+```
+
+Two things to know:
+
+**Nothing validates formulas.** `=NOTAFUNC(A1)` and unbalanced parentheses reach
+the file unchanged and surface only when a spreadsheet opens it. A typo in an
+aggregate *name* still raises, because that is a closed set.
+
+**There is no `{last}` in `formula_columns`.** Those cells are written while
+rows are still streaming, so the final row is unknown; the placeholder raises
+with that explanation. Use `totals_row` for whole-column formulas.
 
 ### Totals Row
 

--- a/README.md
+++ b/README.md
@@ -224,12 +224,28 @@ under_header = Format().set_border_bottom("thin")
 | `banded_rows` | Background colour for every other data row |
 | `autofilter` | Filter dropdowns over the header row and its data |
 
+| `url_columns` | Column names whose text cells become clickable links |
+
 `autofilter=True` sizes its own range from the rows actually written, so it
 follows `header_row` and needs no manual bounds:
 
 ```python
 FastExcel("report.xlsx").sheet("Data", rows, autofilter=True, freeze_row=1).save()
 ```
+
+### Hyperlinks
+
+Name the columns that hold links; the cell text stays the URL:
+
+```python
+FastExcel("report.xlsx").sheet("Docs", rows, url_columns=["homepage"]).save()
+```
+
+Accepts what Excel accepts — `http(s)://`, `mailto:`, and `internal:Sheet2!A1`
+to jump to another sheet. Anything Excel would reject (ordinary text, a blank,
+or a URL past its 2083-character limit) is written as plain text instead, so one
+stray value in a column of thousands never aborts the export. Links keep their
+banding and column format.
 
 **Ordering is enforced, not assumed.** Sheets are written row by row and a row
 that has been flushed cannot be revisited — `rust_xlsxwriter` would drop a late

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ under_header = Format().set_border_bottom("thin")
 | `autofilter` | Filter dropdowns over the header row and its data |
 
 | `url_columns` | Column names whose text cells become clickable links |
+| `totals_row` | Aggregate formulas in a row below the data |
 
 `autofilter=True` sizes its own range from the rows actually written, so it
 follows `header_row` and needs no manual bounds:
@@ -232,6 +233,40 @@ follows `header_row` and needs no manual bounds:
 ```python
 FastExcel("report.xlsx").sheet("Data", rows, autofilter=True, freeze_row=1).save()
 ```
+
+### Totals Row
+
+Aggregate formulas in a row below the data. The ranges are derived from the
+rows actually written:
+
+```python
+(
+    FastExcel("report.xlsx")
+    .sheet(
+        "Sales",
+        rows,
+        totals_row={"amount": "sum", "qty": "sum"},
+        totals_label="Total",
+        totals_format=Format().set_bold().set_border_top("thin"),
+    )
+    .save()
+)
+# amount column gets  =SUM(C2:C101)
+```
+
+Aggregates: `sum`, `average` (`avg`/`mean`), `count`, `min`, `max`, `product`,
+`stdev`. An unknown one raises rather than writing a broken formula. The row is
+skipped entirely when there are no data rows, since the range would be empty,
+and `autofilter` deliberately stops above it so sorting never drags the total
+into the data.
+
+`totals_format` exists because the totals row index depends on how much data
+there was, so `row_formats` cannot reach it.
+
+> **The formulas carry no computed result.** Readers that use cached values —
+> `pandas.read_excel`, `openpyxl` with `data_only=True` — see `0` until Excel or
+> LibreOffice opens the file and recalculates. Use the totals row for files
+> people will open, not for a machine-readable handoff.
 
 ### Hyperlinks
 

--- a/README.md
+++ b/README.md
@@ -272,9 +272,17 @@ totals_row={"qty": "sum", "price": "=ROUND(AVERAGE({col}{first}:{col}{last}),2)"
 
 Two things to know:
 
-**Nothing validates formulas.** `=NOTAFUNC(A1)` and unbalanced parentheses reach
-the file unchanged and surface only when a spreadsheet opens it. A typo in an
-aggregate *name* still raises, because that is a closed set.
+**Structure is validated, names are not.** Unbalanced parentheses or quotes and
+an empty formula raise at write time, naming the column and echoing the
+formula. Function names are not checked: `LAMBDA` and `LET` bind their own,
+workbooks carry user-defined functions, and Excel keeps adding to the list, so a
+whitelist would reject valid formulas. `=NOTAFUNC(A1)` therefore reaches the
+file and shows `#NAME?` in that cell.
+
+For context, a malformed formula never corrupts the file — every case tested
+opens fine and shows an error value in the one cell. Validation just moves the
+discovery from "when someone opens the report" to "when the export runs", which
+is why it stops at the checks that cannot produce a false positive.
 
 **There is no `{last}` in `formula_columns`.** Those cells are written while
 rows are still streaming, so the final row is unknown; the placeholder raises

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ xlsx_bytes = buf.getvalue()  # send as HTTP response
 ### CSV / TSV Output
 
 ```python
-# Auto-detected from file extension — same API, no code change
+# Auto-detected from file extension
 FastExcel("output.csv").sheet("Sheet1", records).save()
 FastExcel("output.tsv").sheet("Sheet1", records).save()
 
@@ -311,6 +311,20 @@ from rustpy_xlsxwriter import write_csv
 write_csv(records, "output.csv")
 write_csv(records, "output.csv", delimiter=";")  # custom delimiter
 ```
+
+CSV carries no formatting, so every Excel-only option is dropped —
+`float_format`, `column_formats`, `header_format`, freeze panes, merges,
+banding, row heights and formats, `password`, `dedupe_strings`. Only
+`delimiter` and `sanitize_formulas` apply. Switching a target from `.xlsx` to
+`.csv` therefore silently changes the output, so the builder warns and names
+what it discarded:
+
+```python
+FastExcel("out.csv").format(float_format="0.00").sheet("S", rows).save()
+# UserWarning: CSV/TSV output ignores Excel-only options: float_format. …
+```
+
+The data is still written correctly — only the styling is gone.
 
 ### Functional API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ tests = ["pytest", "XlsxWriter", "pytest-codspeed", "faker", "openpyxl", "pandas
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+
+[tool.pytest.ini_options]
+markers = [
+    "benchmark: performance benchmarks, deselected by default in CI",
+    "recalc: opens output in LibreOffice to verify computed formula results",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pytest-codspeed==5.0.3
 python-dateutil==2.9.0.post0
 pytokens==0.4.1
 rich==15.0.0
--e git+ssh://git@github.com/rahmadafandi/rustpy-xlsxwriter.git@c42b28d5ad71d34ca02485693e1613dc48494f60#egg=rustpy_xlsxwriter
+-e .
 semantic-version==2.10.0
 setuptools==83.0.0
 setuptools-rust==1.13.0

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -152,6 +152,27 @@ __version__ = get_version()
 # Builder-style class wrapper
 # ---------------------------------------------------------------------------
 
+#: Options ``sheet()`` records per sheet and forwards to the writers. Both save
+#: paths iterate this, so adding an option means touching only ``sheet()``.
+_PER_SHEET_OPTIONS = (
+    "column_width",
+    "column_widths",
+    "column_formats",
+    "header_format",
+    "dedupe_strings",
+    "header_row",
+    "merge_ranges",
+    "row_heights",
+    "row_formats",
+    "banded_rows",
+    "autofilter",
+    "url_columns",
+    "totals_row",
+    "totals_label",
+    "totals_format",
+    "formula_columns",
+)
+
 
 class FastExcel:
     """Fluent builder for creating Excel files.
@@ -213,22 +234,10 @@ class FastExcel:
         self._index_columns: Optional[List[str]] = None
         self._bold_headers: bool = False
         self._freeze_panes: Dict[str, Dict[str, int]] = {}
-        self._col_width: Dict[str, float] = {}
-        self._col_widths: Dict[str, Union[Dict[str, float], List[float]]] = {}
-        self._col_formats: Dict[str, Any] = {}
-        self._header_format: Dict[str, Any] = {}
-        self._dedupe_strings: Dict[str, bool] = {}
-        self._header_row: Dict[str, int] = {}
-        self._merge_ranges: Dict[str, Any] = {}
-        self._row_heights: Dict[str, Dict[int, float]] = {}
-        self._row_formats: Dict[str, Dict[int, Any]] = {}
-        self._banded_rows: Dict[str, str] = {}
-        self._autofilter: Dict[str, bool] = {}
-        self._url_columns: Dict[str, List[str]] = {}
-        self._totals_row: Dict[str, Dict[str, str]] = {}
-        self._totals_label: Dict[str, str] = {}
-        self._totals_format: Dict[str, Any] = {}
-        self._formula_columns: Dict[str, Dict[str, str]] = {}
+        # {option: {sheet_name: value}} — see _PER_SHEET_OPTIONS.
+        self._per_sheet: Dict[str, Dict[str, Any]] = {
+            option: {} for option in _PER_SHEET_OPTIONS
+        }
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -372,12 +381,11 @@ class FastExcel:
 
                     totals_row={"margin": "=SUM({col}{first}:{col}{last})/2"}
 
-                Skipped
-                entirely when there are no data rows, since the range would be
-                empty. NOTE: the formulas are written without a computed result,
-                so readers that use cached values (``pandas.read_excel``,
-                ``openpyxl`` with ``data_only=True``) see ``0`` until Excel or
-                LibreOffice opens the file and recalculates.
+                Skipped entirely when there are no data rows, since the range
+                would be empty. NOTE: the formulas carry no computed result, so
+                readers that use cached values (``pandas.read_excel``,
+                ``openpyxl`` with ``data_only=True``) get ``None`` until Excel
+                or LibreOffice opens the file and recalculates.
             totals_label: Text for the first column of the totals row, e.g.
                 ``"Total"``. Raises if the first column also has an aggregate.
             totals_format: :class:`Format` for the whole totals row — the usual
@@ -394,9 +402,10 @@ class FastExcel:
                 anything Excel accepts works: nested calls, ``SUMIFS``,
                 cross-sheet references, and modern functions like ``XLOOKUP`` or
                 ``TEXTJOIN`` (which are rewritten with the ``_xlfn.`` prefix and
-                dynamic-array metadata automatically). Nothing validates the
-                formula — a typo reaches the file and surfaces when a
-                spreadsheet opens it. There is no ``{last}``: rows are still
+                dynamic-array metadata automatically). Structure is checked —
+                unbalanced parentheses or quotes raise — but function names are
+                not, so ``=NOTAFUNC(A1)`` reaches the file and shows ``#NAME?``.
+                There is no ``{last}``: rows are still
                 streaming when these are written, so the final row is unknown;
                 use ``totals_row`` for whole-column formulas.
 
@@ -405,38 +414,29 @@ class FastExcel:
                 merge range overlaps the header/data rows.
         """
         self._sheets.append((name, data))
-        if dedupe_strings:
-            self._dedupe_strings[name] = True
-        if header_row:
-            self._header_row[name] = header_row
-        if merge_ranges is not None:
-            self._merge_ranges[name] = merge_ranges
-        if row_heights is not None:
-            self._row_heights[name] = row_heights
-        if row_formats is not None:
-            self._row_formats[name] = row_formats
-        if banded_rows is not None:
-            self._banded_rows[name] = banded_rows
-        if autofilter:
-            self._autofilter[name] = True
-        if url_columns is not None:
-            self._url_columns[name] = url_columns
-        if totals_row is not None:
-            self._totals_row[name] = totals_row
-        if totals_label is not None:
-            self._totals_label[name] = totals_label
-        if totals_format is not None:
-            self._totals_format[name] = totals_format
-        if formula_columns is not None:
-            self._formula_columns[name] = formula_columns
-        if column_width is not None:
-            self._col_width[name] = column_width
-        if column_widths is not None:
-            self._col_widths[name] = column_widths
-        if column_formats is not None:
-            self._col_formats[name] = column_formats
-        if header_format is not None:
-            self._header_format[name] = header_format
+        # Only options actually given are recorded, so the writers keep their
+        # own defaults for the rest — and a CSV target only warns about options
+        # that were really set.
+        for option, value in {
+            "column_width": column_width,
+            "column_widths": column_widths,
+            "column_formats": column_formats,
+            "header_format": header_format,
+            "dedupe_strings": dedupe_strings,
+            "header_row": header_row,
+            "merge_ranges": merge_ranges,
+            "row_heights": row_heights,
+            "row_formats": row_formats,
+            "banded_rows": banded_rows,
+            "autofilter": autofilter,
+            "url_columns": url_columns,
+            "totals_row": totals_row,
+            "totals_label": totals_label,
+            "totals_format": totals_format,
+            "formula_columns": formula_columns,
+        }.items():
+            if value:
+                self._per_sheet[option][name] = value
         return self
 
     # -- output -------------------------------------------------------------
@@ -447,31 +447,19 @@ class FastExcel:
         ``autofit`` and ``sanitize_formulas`` are left out: the first is on by
         default so it would fire on every CSV write, and the second is CSV-only.
         """
-        configured = {
+        workbook_wide = {
             "password": self._password,
             "float_format": self._float_format,
             "datetime_format": self._datetime_format,
             "index_columns": self._index_columns,
             "bold_headers": self._bold_headers,
             "freeze": self._freeze_panes,
-            "column_width": self._col_width,
-            "column_widths": self._col_widths,
-            "column_formats": self._col_formats,
-            "header_format": self._header_format,
-            "dedupe_strings": self._dedupe_strings,
-            "header_row": self._header_row,
-            "merge_ranges": self._merge_ranges,
-            "row_heights": self._row_heights,
-            "row_formats": self._row_formats,
-            "banded_rows": self._banded_rows,
-            "autofilter": self._autofilter,
-            "url_columns": self._url_columns,
-            "totals_row": self._totals_row,
-            "totals_label": self._totals_label,
-            "totals_format": self._totals_format,
-            "formula_columns": self._formula_columns,
         }
-        return [name for name, value in configured.items() if value]
+        names = [name for name, value in workbook_wide.items() if value]
+        names += [
+            option for option in _PER_SHEET_OPTIONS if self._per_sheet[option]
+        ]
+        return names
 
     def save(self) -> None:
         """Write all sheets to the target file or buffer.
@@ -528,9 +516,6 @@ class FastExcel:
                 freeze_row = cfg.get("row")
                 freeze_col = cfg.get("col")
 
-            cw = self._col_width.get(sheet_name)
-            cws = self._col_widths.get(sheet_name)
-
             write_worksheet(
                 data,
                 self._target,
@@ -543,22 +528,11 @@ class FastExcel:
                 index_columns=self._index_columns,
                 autofit=self._autofit,
                 bold_headers=self._bold_headers,
-                column_width=cw,
-                column_widths=cws,
-                column_formats=self._col_formats.get(sheet_name),
-                header_format=self._header_format.get(sheet_name),
-                dedupe_strings=self._dedupe_strings.get(sheet_name, False),
-                header_row=self._header_row.get(sheet_name, 0),
-                merge_ranges=self._merge_ranges.get(sheet_name),
-                row_heights=self._row_heights.get(sheet_name),
-                row_formats=self._row_formats.get(sheet_name),
-                banded_rows=self._banded_rows.get(sheet_name),
-                autofilter=self._autofilter.get(sheet_name, False),
-                url_columns=self._url_columns.get(sheet_name),
-                totals_row=self._totals_row.get(sheet_name),
-                totals_label=self._totals_label.get(sheet_name),
-                totals_format=self._totals_format.get(sheet_name),
-                formula_columns=self._formula_columns.get(sheet_name),
+                **{
+                    option: values[sheet_name]
+                    for option, values in self._per_sheet.items()
+                    if sheet_name in values
+                },
             )
         else:
             # Multi-sheet path
@@ -572,22 +546,11 @@ class FastExcel:
                 index_columns=self._index_columns,
                 autofit=self._autofit,
                 bold_headers=self._bold_headers,
-                column_width=self._col_width or None,
-                column_widths=self._col_widths or None,
-                column_formats=self._col_formats or None,
-                header_format=self._header_format or None,
-                dedupe_strings=self._dedupe_strings or None,
-                header_row=self._header_row or None,
-                merge_ranges=self._merge_ranges or None,
-                row_heights=self._row_heights or None,
-                row_formats=self._row_formats or None,
-                banded_rows=self._banded_rows or None,
-                autofilter=self._autofilter or None,
-                url_columns=self._url_columns or None,
-                totals_row=self._totals_row or None,
-                totals_label=self._totals_label or None,
-                totals_format=self._totals_format or None,
-                formula_columns=self._formula_columns or None,
+                **{
+                    option: values
+                    for option, values in self._per_sheet.items()
+                    if values
+                },
             )
 
 

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -228,6 +228,7 @@ class FastExcel:
         self._totals_row: Dict[str, Dict[str, str]] = {}
         self._totals_label: Dict[str, str] = {}
         self._totals_format: Dict[str, Any] = {}
+        self._formula_columns: Dict[str, Dict[str, str]] = {}
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -312,6 +313,7 @@ class FastExcel:
         totals_row: Optional[Dict[str, str]] = None,
         totals_label: Optional[str] = None,
         totals_format: Optional["Format"] = None,
+        formula_columns: Optional[Dict[str, str]] = None,
     ) -> "FastExcel":
         """Add a worksheet with data.
 
@@ -364,7 +366,13 @@ class FastExcel:
             totals_row: ``{column_name: aggregate}`` written as Excel formulas
                 in a row below the data — ``{"amount": "sum"}`` becomes
                 ``=SUM(C2:C101)``. Valid aggregates: ``sum``, ``average``,
-                ``count``, ``min``, ``max``, ``product``, ``stdev``. Skipped
+                ``count``, ``min``, ``max``, ``product``, ``stdev``. A value
+                starting with ``=`` is used as a formula instead, with ``{col}``
+                the column letter and ``{first}``/``{last}`` the data range::
+
+                    totals_row={"margin": "=SUM({col}{first}:{col}{last})/2"}
+
+                Skipped
                 entirely when there are no data rows, since the range would be
                 empty. NOTE: the formulas are written without a computed result,
                 so readers that use cached values (``pandas.read_excel``,
@@ -375,6 +383,22 @@ class FastExcel:
             totals_format: :class:`Format` for the whole totals row — the usual
                 bold plus a top border. Needed because the row index is not
                 known ahead of time, so ``row_formats`` cannot reach it.
+            formula_columns: ``{header: formula}`` — extra columns appended after
+                the data, one formula per data row. ``{row}`` is replaced with
+                that row's 1-based sheet row and ``{first}`` with the first data
+                row::
+
+                    formula_columns={"total": "=B{row}*C{row}"}
+
+                The formula text is passed through to Excel unchanged, so
+                anything Excel accepts works: nested calls, ``SUMIFS``,
+                cross-sheet references, and modern functions like ``XLOOKUP`` or
+                ``TEXTJOIN`` (which are rewritten with the ``_xlfn.`` prefix and
+                dynamic-array metadata automatically). Nothing validates the
+                formula — a typo reaches the file and surfaces when a
+                spreadsheet opens it. There is no ``{last}``: rows are still
+                streaming when these are written, so the final row is unknown;
+                use ``totals_row`` for whole-column formulas.
 
         Raises:
             ValueError: If the sheet name is invalid (validated on save), or a
@@ -403,6 +427,8 @@ class FastExcel:
             self._totals_label[name] = totals_label
         if totals_format is not None:
             self._totals_format[name] = totals_format
+        if formula_columns is not None:
+            self._formula_columns[name] = formula_columns
         if column_width is not None:
             self._col_width[name] = column_width
         if column_widths is not None:
@@ -443,6 +469,7 @@ class FastExcel:
             "totals_row": self._totals_row,
             "totals_label": self._totals_label,
             "totals_format": self._totals_format,
+            "formula_columns": self._formula_columns,
         }
         return [name for name, value in configured.items() if value]
 
@@ -531,6 +558,7 @@ class FastExcel:
                 totals_row=self._totals_row.get(sheet_name),
                 totals_label=self._totals_label.get(sheet_name),
                 totals_format=self._totals_format.get(sheet_name),
+                formula_columns=self._formula_columns.get(sheet_name),
             )
         else:
             # Multi-sheet path
@@ -559,6 +587,7 @@ class FastExcel:
                 totals_row=self._totals_row or None,
                 totals_label=self._totals_label or None,
                 totals_format=self._totals_format or None,
+                formula_columns=self._formula_columns or None,
             )
 
 

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -225,6 +225,9 @@ class FastExcel:
         self._banded_rows: Dict[str, str] = {}
         self._autofilter: Dict[str, bool] = {}
         self._url_columns: Dict[str, List[str]] = {}
+        self._totals_row: Dict[str, Dict[str, str]] = {}
+        self._totals_label: Dict[str, str] = {}
+        self._totals_format: Dict[str, Any] = {}
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -306,6 +309,9 @@ class FastExcel:
         banded_rows: Optional[str] = None,
         autofilter: bool = False,
         url_columns: Optional[List[str]] = None,
+        totals_row: Optional[Dict[str, str]] = None,
+        totals_label: Optional[str] = None,
+        totals_format: Optional["Format"] = None,
     ) -> "FastExcel":
         """Add a worksheet with data.
 
@@ -355,6 +361,20 @@ class FastExcel:
                 its 2083-character limit) is written as plain text instead, so a
                 stray non-link never aborts the export. The cell displays the
                 URL itself; per-cell display text is not supported.
+            totals_row: ``{column_name: aggregate}`` written as Excel formulas
+                in a row below the data — ``{"amount": "sum"}`` becomes
+                ``=SUM(C2:C101)``. Valid aggregates: ``sum``, ``average``,
+                ``count``, ``min``, ``max``, ``product``, ``stdev``. Skipped
+                entirely when there are no data rows, since the range would be
+                empty. NOTE: the formulas are written without a computed result,
+                so readers that use cached values (``pandas.read_excel``,
+                ``openpyxl`` with ``data_only=True``) see ``0`` until Excel or
+                LibreOffice opens the file and recalculates.
+            totals_label: Text for the first column of the totals row, e.g.
+                ``"Total"``. Raises if the first column also has an aggregate.
+            totals_format: :class:`Format` for the whole totals row — the usual
+                bold plus a top border. Needed because the row index is not
+                known ahead of time, so ``row_formats`` cannot reach it.
 
         Raises:
             ValueError: If the sheet name is invalid (validated on save), or a
@@ -377,6 +397,12 @@ class FastExcel:
             self._autofilter[name] = True
         if url_columns is not None:
             self._url_columns[name] = url_columns
+        if totals_row is not None:
+            self._totals_row[name] = totals_row
+        if totals_label is not None:
+            self._totals_label[name] = totals_label
+        if totals_format is not None:
+            self._totals_format[name] = totals_format
         if column_width is not None:
             self._col_width[name] = column_width
         if column_widths is not None:
@@ -414,6 +440,9 @@ class FastExcel:
             "banded_rows": self._banded_rows,
             "autofilter": self._autofilter,
             "url_columns": self._url_columns,
+            "totals_row": self._totals_row,
+            "totals_label": self._totals_label,
+            "totals_format": self._totals_format,
         }
         return [name for name, value in configured.items() if value]
 
@@ -499,6 +528,9 @@ class FastExcel:
                 banded_rows=self._banded_rows.get(sheet_name),
                 autofilter=self._autofilter.get(sheet_name, False),
                 url_columns=self._url_columns.get(sheet_name),
+                totals_row=self._totals_row.get(sheet_name),
+                totals_label=self._totals_label.get(sheet_name),
+                totals_format=self._totals_format.get(sheet_name),
             )
         else:
             # Multi-sheet path
@@ -524,6 +556,9 @@ class FastExcel:
                 banded_rows=self._banded_rows or None,
                 autofilter=self._autofilter or None,
                 url_columns=self._url_columns or None,
+                totals_row=self._totals_row or None,
+                totals_label=self._totals_label or None,
+                totals_format=self._totals_format or None,
             )
 
 

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -223,6 +223,7 @@ class FastExcel:
         self._row_heights: Dict[str, Dict[int, float]] = {}
         self._row_formats: Dict[str, Dict[int, Any]] = {}
         self._banded_rows: Dict[str, str] = {}
+        self._autofilter: Dict[str, bool] = {}
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -302,6 +303,7 @@ class FastExcel:
         row_heights: Optional[Dict[int, float]] = None,
         row_formats: Optional[Dict[int, "Format"]] = None,
         banded_rows: Optional[str] = None,
+        autofilter: bool = False,
     ) -> "FastExcel":
         """Add a worksheet with data.
 
@@ -341,6 +343,9 @@ class FastExcel:
                 every other data row, starting with the second. Applied per cell
                 rather than per row, so columns with their own number format
                 stay shaded too.
+            autofilter: Add Excel's filter dropdowns over the header row and its
+                data. The range is computed from the rows actually written, so
+                it follows ``header_row`` and needs no manual bounds.
 
         Raises:
             ValueError: If the sheet name is invalid (validated on save), or a
@@ -359,6 +364,8 @@ class FastExcel:
             self._row_formats[name] = row_formats
         if banded_rows is not None:
             self._banded_rows[name] = banded_rows
+        if autofilter:
+            self._autofilter[name] = True
         if column_width is not None:
             self._col_width[name] = column_width
         if column_widths is not None:
@@ -394,6 +401,7 @@ class FastExcel:
             "row_heights": self._row_heights,
             "row_formats": self._row_formats,
             "banded_rows": self._banded_rows,
+            "autofilter": self._autofilter,
         }
         return [name for name, value in configured.items() if value]
 
@@ -477,6 +485,7 @@ class FastExcel:
                 row_heights=self._row_heights.get(sheet_name),
                 row_formats=self._row_formats.get(sheet_name),
                 banded_rows=self._banded_rows.get(sheet_name),
+                autofilter=self._autofilter.get(sheet_name, False),
             )
         else:
             # Multi-sheet path
@@ -500,6 +509,7 @@ class FastExcel:
                 row_heights=self._row_heights or None,
                 row_formats=self._row_formats or None,
                 banded_rows=self._banded_rows or None,
+                autofilter=self._autofilter or None,
             )
 
 

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -224,6 +224,7 @@ class FastExcel:
         self._row_formats: Dict[str, Dict[int, Any]] = {}
         self._banded_rows: Dict[str, str] = {}
         self._autofilter: Dict[str, bool] = {}
+        self._url_columns: Dict[str, List[str]] = {}
 
     def __enter__(self) -> "FastExcel":
         return self
@@ -304,6 +305,7 @@ class FastExcel:
         row_formats: Optional[Dict[int, "Format"]] = None,
         banded_rows: Optional[str] = None,
         autofilter: bool = False,
+        url_columns: Optional[List[str]] = None,
     ) -> "FastExcel":
         """Add a worksheet with data.
 
@@ -346,6 +348,13 @@ class FastExcel:
             autofilter: Add Excel's filter dropdowns over the header row and its
                 data. The range is computed from the rows actually written, so
                 it follows ``header_row`` and needs no manual bounds.
+            url_columns: Column names whose text cells become clickable links —
+                ``["homepage"]``. Accepts what Excel accepts: ``http(s)://``,
+                ``mailto:``, and ``internal:Sheet2!A1`` for a link to another
+                sheet. A value Excel would reject (ordinary text, or a URL past
+                its 2083-character limit) is written as plain text instead, so a
+                stray non-link never aborts the export. The cell displays the
+                URL itself; per-cell display text is not supported.
 
         Raises:
             ValueError: If the sheet name is invalid (validated on save), or a
@@ -366,6 +375,8 @@ class FastExcel:
             self._banded_rows[name] = banded_rows
         if autofilter:
             self._autofilter[name] = True
+        if url_columns is not None:
+            self._url_columns[name] = url_columns
         if column_width is not None:
             self._col_width[name] = column_width
         if column_widths is not None:
@@ -402,6 +413,7 @@ class FastExcel:
             "row_formats": self._row_formats,
             "banded_rows": self._banded_rows,
             "autofilter": self._autofilter,
+            "url_columns": self._url_columns,
         }
         return [name for name, value in configured.items() if value]
 
@@ -486,6 +498,7 @@ class FastExcel:
                 row_formats=self._row_formats.get(sheet_name),
                 banded_rows=self._banded_rows.get(sheet_name),
                 autofilter=self._autofilter.get(sheet_name, False),
+                url_columns=self._url_columns.get(sheet_name),
             )
         else:
             # Multi-sheet path
@@ -510,6 +523,7 @@ class FastExcel:
                 row_formats=self._row_formats or None,
                 banded_rows=self._banded_rows or None,
                 autofilter=self._autofilter or None,
+                url_columns=self._url_columns or None,
             )
 
 

--- a/rustpy_xlsxwriter/__init__.py
+++ b/rustpy_xlsxwriter/__init__.py
@@ -64,6 +64,7 @@ from typing import (
 )
 
 import os as _os
+import warnings as _warnings
 from importlib.metadata import metadata as _metadata
 from importlib.metadata import version as _version
 
@@ -370,6 +371,32 @@ class FastExcel:
 
     # -- output -------------------------------------------------------------
 
+    def _excel_only_options(self) -> List[str]:
+        """Names of set options that only apply to ``.xlsx`` output.
+
+        ``autofit`` and ``sanitize_formulas`` are left out: the first is on by
+        default so it would fire on every CSV write, and the second is CSV-only.
+        """
+        configured = {
+            "password": self._password,
+            "float_format": self._float_format,
+            "datetime_format": self._datetime_format,
+            "index_columns": self._index_columns,
+            "bold_headers": self._bold_headers,
+            "freeze": self._freeze_panes,
+            "column_width": self._col_width,
+            "column_widths": self._col_widths,
+            "column_formats": self._col_formats,
+            "header_format": self._header_format,
+            "dedupe_strings": self._dedupe_strings,
+            "header_row": self._header_row,
+            "merge_ranges": self._merge_ranges,
+            "row_heights": self._row_heights,
+            "row_formats": self._row_formats,
+            "banded_rows": self._banded_rows,
+        }
+        return [name for name, value in configured.items() if value]
+
     def save(self) -> None:
         """Write all sheets to the target file or buffer.
 
@@ -395,6 +422,15 @@ class FastExcel:
                     )
                 delimiter = "\t" if lower.endswith(".tsv") else ","
                 _, data = self._sheets[0]
+                ignored = self._excel_only_options()
+                if ignored:
+                    _warnings.warn(
+                        "CSV/TSV output ignores Excel-only options: "
+                        f"{', '.join(ignored)}. "
+                        "The file will contain unformatted values; write to "
+                        "'.xlsx' if you need them.",
+                        stacklevel=2,
+                    )
                 write_csv(
                     data,
                     self._target,

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -285,6 +285,7 @@ def write_worksheet(
     row_heights: Optional[Dict[int, float]] = None,
     row_formats: Optional[Dict[int, Format]] = None,
     banded_rows: Optional[str] = None,
+    autofilter: bool = False,
 ) -> None:
     """Write data to a **single** worksheet in an Excel file.
 
@@ -313,6 +314,7 @@ def write_worksheet(
         row_heights: ``{row_index: height}`` in points.
         row_formats: ``{row_index: Format}`` applied to the whole row.
         banded_rows: Background colour shaded onto every other data row.
+        autofilter: Add filter dropdowns over the header row and its data.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -343,6 +345,7 @@ def write_worksheets(
     row_heights: Optional[Dict[str, Dict[int, float]]] = None,
     row_formats: Optional[Dict[str, Dict[int, Format]]] = None,
     banded_rows: Optional[Dict[str, str]] = None,
+    autofilter: Optional[Dict[str, bool]] = None,
 ) -> None:
     """Write data to **multiple** worksheets in an Excel file.
 
@@ -364,6 +367,7 @@ def write_worksheets(
         row_heights: Per-sheet row heights — dict keyed by sheet name.
         row_formats: Per-sheet row formats — dict keyed by sheet name.
         banded_rows: Per-sheet alternating row colour — dict keyed by sheet name.
+        autofilter: Per-sheet filter dropdowns — dict keyed by sheet name.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -287,6 +287,9 @@ def write_worksheet(
     banded_rows: Optional[str] = None,
     autofilter: bool = False,
     url_columns: Optional[List[str]] = None,
+    totals_row: Optional[Dict[str, str]] = None,
+    totals_label: Optional[str] = None,
+    totals_format: Optional[Format] = None,
 ) -> None:
     """Write data to a **single** worksheet in an Excel file.
 
@@ -318,6 +321,10 @@ def write_worksheet(
         autofilter: Add filter dropdowns over the header row and its data.
         url_columns: Column names whose text cells become clickable links.
             Values Excel rejects fall back to plain text.
+        totals_row: ``{column_name: aggregate}`` written as formulas below the
+            data. Valid: sum, average, count, min, max, product, stdev.
+        totals_label: Text for the first column of the totals row.
+        totals_format: Format applied to the whole totals row.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -350,6 +357,9 @@ def write_worksheets(
     banded_rows: Optional[Dict[str, str]] = None,
     autofilter: Optional[Dict[str, bool]] = None,
     url_columns: Optional[Dict[str, List[str]]] = None,
+    totals_row: Optional[Dict[str, Dict[str, str]]] = None,
+    totals_label: Optional[Dict[str, str]] = None,
+    totals_format: Optional[Dict[str, Format]] = None,
 ) -> None:
     """Write data to **multiple** worksheets in an Excel file.
 
@@ -373,6 +383,9 @@ def write_worksheets(
         banded_rows: Per-sheet alternating row colour — dict keyed by sheet name.
         autofilter: Per-sheet filter dropdowns — dict keyed by sheet name.
         url_columns: Per-sheet link columns — dict keyed by sheet name.
+        totals_row: Per-sheet totals formulas — dict keyed by sheet name.
+        totals_label: Per-sheet totals label — dict keyed by sheet name.
+        totals_format: Per-sheet totals row format — dict keyed by sheet name.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -290,6 +290,7 @@ def write_worksheet(
     totals_row: Optional[Dict[str, str]] = None,
     totals_label: Optional[str] = None,
     totals_format: Optional[Format] = None,
+    formula_columns: Optional[Dict[str, str]] = None,
 ) -> None:
     """Write data to a **single** worksheet in an Excel file.
 
@@ -325,6 +326,8 @@ def write_worksheet(
             data. Valid: sum, average, count, min, max, product, stdev.
         totals_label: Text for the first column of the totals row.
         totals_format: Format applied to the whole totals row.
+        formula_columns: ``{header: formula}`` appended after the data, one
+            formula per row. ``{row}``/``{first}`` are substituted.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -360,6 +363,7 @@ def write_worksheets(
     totals_row: Optional[Dict[str, Dict[str, str]]] = None,
     totals_label: Optional[Dict[str, str]] = None,
     totals_format: Optional[Dict[str, Format]] = None,
+    formula_columns: Optional[Dict[str, Dict[str, str]]] = None,
 ) -> None:
     """Write data to **multiple** worksheets in an Excel file.
 
@@ -386,6 +390,7 @@ def write_worksheets(
         totals_row: Per-sheet totals formulas — dict keyed by sheet name.
         totals_label: Per-sheet totals label — dict keyed by sheet name.
         totals_format: Per-sheet totals row format — dict keyed by sheet name.
+        formula_columns: Per-sheet computed columns — dict keyed by sheet name.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -286,6 +286,7 @@ def write_worksheet(
     row_formats: Optional[Dict[int, Format]] = None,
     banded_rows: Optional[str] = None,
     autofilter: bool = False,
+    url_columns: Optional[List[str]] = None,
 ) -> None:
     """Write data to a **single** worksheet in an Excel file.
 
@@ -315,6 +316,8 @@ def write_worksheet(
         row_formats: ``{row_index: Format}`` applied to the whole row.
         banded_rows: Background colour shaded onto every other data row.
         autofilter: Add filter dropdowns over the header row and its data.
+        url_columns: Column names whose text cells become clickable links.
+            Values Excel rejects fall back to plain text.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.
@@ -346,6 +349,7 @@ def write_worksheets(
     row_formats: Optional[Dict[str, Dict[int, Format]]] = None,
     banded_rows: Optional[Dict[str, str]] = None,
     autofilter: Optional[Dict[str, bool]] = None,
+    url_columns: Optional[Dict[str, List[str]]] = None,
 ) -> None:
     """Write data to **multiple** worksheets in an Excel file.
 
@@ -368,6 +372,7 @@ def write_worksheets(
         row_formats: Per-sheet row formats — dict keyed by sheet name.
         banded_rows: Per-sheet alternating row colour — dict keyed by sheet name.
         autofilter: Per-sheet filter dropdowns — dict keyed by sheet name.
+        url_columns: Per-sheet link columns — dict keyed by sheet name.
 
     Raises:
         ValueError: Invalid sheet name or unsupported data type.

--- a/src/arrow_writer.rs
+++ b/src/arrow_writer.rs
@@ -91,6 +91,7 @@ fn write_temporal(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn write_arrow_batch(
     worksheet: &mut Worksheet,
     batch: &RecordBatch,
@@ -99,6 +100,8 @@ pub fn write_arrow_batch(
     banded: Option<&crate::format::RowPalette>,
     layout: &crate::helpers::SheetLayout,
     url_cols: &[bool],
+    formula_cols: &[crate::helpers::FormulaColumn],
+    n_data_cols: usize,
 ) -> PyResult<()> {
     let num_cols = batch.num_columns();
     let num_rows = batch.num_rows();
@@ -245,6 +248,18 @@ pub fn write_arrow_batch(
                     write_string_opt(worksheet, row_u32, col_u16, "", text_fmt)?;
                 }
             }
+        }
+        // Written inside the row loop: constant-memory mode flushes each row as
+        // the next begins, so a pass afterwards would be ignored.
+        if !formula_cols.is_empty() {
+            crate::helpers::write_formula_row(
+                worksheet,
+                formula_cols,
+                n_data_cols as u16,
+                row_u32,
+                layout.first_data_row(),
+                None,
+            )?;
         }
     }
 

--- a/src/arrow_writer.rs
+++ b/src/arrow_writer.rs
@@ -98,6 +98,7 @@ pub fn write_arrow_batch(
     plain: &crate::format::RowPalette,
     banded: Option<&crate::format::RowPalette>,
     layout: &crate::helpers::SheetLayout,
+    url_cols: &[bool],
 ) -> PyResult<()> {
     let num_cols = batch.num_columns();
     let num_rows = batch.num_rows();
@@ -143,10 +144,20 @@ pub fn write_arrow_batch(
                     write_number_opt(worksheet, row_u32, col_u16, val, col_override)?;
                 }};
             }
+            // A url_columns entry turns text cells into links; anything that
+            // is not a valid URL falls back to plain text.
+            let as_url = url_cols.get(col_idx).copied().unwrap_or(false);
             macro_rules! write_str {
-                ($val:expr) => {
-                    write_string_opt(worksheet, row_u32, col_u16, $val, col_override)?
-                };
+                ($val:expr) => {{
+                    let val: &str = $val;
+                    if as_url && !val.is_empty() {
+                        crate::helpers::write_url_or_text(
+                            worksheet, row_u32, col_u16, val, col_override,
+                        )?
+                    } else {
+                        write_string_opt(worksheet, row_u32, col_u16, val, col_override)?
+                    }
+                }};
             }
 
             match kinds[col_idx] {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -375,6 +375,57 @@ pub fn write_string_opt(
     Ok(())
 }
 
+/// Write a string as a clickable link, falling back to plain text when it is
+/// not one.
+///
+/// `write_url` rejects anything it cannot classify — ordinary text, an empty
+/// string, or a URL past Excel's 2083-character limit — so calling it blindly
+/// over a column would abort the whole export on the first blank cell. A value
+/// that is not a link is therefore written as its literal text: visible and
+/// correct, just not clickable.
+pub fn write_url_or_text(
+    worksheet: &mut Worksheet,
+    row: u32,
+    col: u16,
+    val: &str,
+    fmt: Option<&Format>,
+) -> PyResult<()> {
+    let wrote = match fmt {
+        Some(f) => worksheet.write_url_with_format(row, col, val, f).is_ok(),
+        None => worksheet.write_url(row, col, val).is_ok(),
+    };
+    if wrote {
+        return Ok(());
+    }
+    write_string_opt(worksheet, row, col, val, fmt)
+}
+
+/// Resolve `url_columns` (column names) to their positions in `headers`.
+/// Unknown names warn and are skipped, matching `column_formats`.
+pub fn resolve_url_columns(
+    url_columns: Option<&Vec<String>>,
+    headers: &[String],
+    py: Python,
+) -> PyResult<Vec<bool>> {
+    let mut flags = vec![false; headers.len()];
+    let Some(names) = url_columns else {
+        return Ok(flags);
+    };
+    let warnings = py.import("warnings")?;
+    for name in names {
+        match headers.iter().position(|h| h == name) {
+            Some(idx) => flags[idx] = true,
+            None => {
+                warnings.call_method1(
+                    "warn",
+                    (format!("url_columns: unknown column '{name}', skipped"),),
+                )?;
+            }
+        }
+    }
+    Ok(flags)
+}
+
 /// Write a boolean cell, with an optional explicit format.
 pub fn write_bool_opt(
     worksheet: &mut Worksheet,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -179,6 +179,14 @@ impl SheetLayout {
         let first = self.first_data_row() + 1;
         let last = self.first_data_row() + data_rows;
 
+        // We don't calculate the formulas, and the crate's default cached
+        // result is 0 — a plausible-looking wrong total for any reader that
+        // trusts the cache (`pandas.read_excel`, `openpyxl` with
+        // `data_only=True`). An empty result reads back as "not computed"
+        // instead, and per rust_xlsxwriter's docs it is also what forces
+        // LibreOffice to recalculate rather than display the stale 0.
+        worksheet.set_formula_result_default("");
+
         let warnings = py.import("warnings")?;
         let mut used_first_column = false;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -86,10 +86,9 @@ pub struct SheetLayout {
     /// [`SheetLayout::apply_autofilter`] — the range needs the final row count,
     /// which is only known once the last row has been written.
     pub autofilter: bool,
-    /// `(column name, Excel function)` for the totals row. Also applied after
-    /// the data: the row sits below it and the formula ranges depend on how
-    /// many rows there turned out to be.
-    /// `(column name, aggregate function or raw formula template)`.
+    /// `(column name, aggregate or raw formula)` for the totals row. Applied
+    /// after the data: the row sits below it and the ranges depend on how many
+    /// rows there turned out to be.
     pub totals: Vec<(String, TotalsCell)>,
     pub totals_label: Option<String>,
     pub totals_format: Option<Format>,
@@ -106,8 +105,8 @@ pub struct SheetLayout {
 /// The formula text is passed to `rust_xlsxwriter` verbatim, so anything Excel
 /// accepts works — nested calls, `SUMIFS`, cross-sheet references, and the 161
 /// functions the crate rewrites with an `_xlfn.` prefix or as a dynamic array.
-/// Nothing here validates the formula: a typo reaches the file unchanged and
-/// surfaces when a spreadsheet opens it.
+/// Only the structure is checked, by [`formula_problem`]; function names and
+/// semantics are Excel's business.
 pub struct FormulaColumn {
     pub header: String,
     pub template: String,
@@ -125,6 +124,71 @@ impl FormulaColumn {
         }
         out
     }
+}
+
+/// Structural check on a formula: balanced parentheses and quotes, and some
+/// content after the `=`.
+///
+/// Deliberately *not* a function-name check. A malformed formula does not
+/// corrupt the file — every case tested opens fine and shows `#NAME?`/`#VALUE!`
+/// in the cell — so the only thing validation buys is catching a typo earlier.
+/// That makes a false positive strictly worse than a false negative: rejecting
+/// a formula Excel would have accepted blocks real work, while letting one
+/// through costs an error value in one cell. Function names cannot be checked
+/// safely — `LAMBDA`/`LET` bind their own names, workbooks carry user-defined
+/// functions, and Excel keeps adding to the list.
+///
+/// Returns the problem description, or `None` when the formula looks sound.
+pub fn formula_problem(formula: &str) -> Option<String> {
+    let body = formula.strip_prefix('=').unwrap_or(formula);
+    if body.trim().is_empty() {
+        return Some("it is empty".to_string());
+    }
+
+    let mut depth: i32 = 0;
+    // Excel quotes strings with `"` (a literal quote inside is doubled) and
+    // wraps sheet names containing spaces or punctuation in `'`. Parentheses
+    // inside either are text, not structure — `='Sheet (1)'!A1` is valid.
+    let mut in_double = false;
+    let mut in_single = false;
+    let chars: Vec<char> = body.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            '"' if !in_single => {
+                if in_double && chars.get(i + 1) == Some(&'"') {
+                    i += 1; // an escaped quote inside a string
+                } else {
+                    in_double = !in_double;
+                }
+            }
+            '\'' if !in_double => in_single = !in_single,
+            '(' if !in_double && !in_single => depth += 1,
+            ')' if !in_double && !in_single => {
+                depth -= 1;
+                if depth < 0 {
+                    return Some("it closes a parenthesis that was never opened".to_string());
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    if in_double {
+        return Some("a double quote is left open".to_string());
+    }
+    if in_single {
+        return Some("a single quote is left open".to_string());
+    }
+    if depth > 0 {
+        return Some(format!(
+            "{depth} parenthesis{} left unclosed",
+            if depth == 1 { " is" } else { "es are" }
+        ));
+    }
+    None
 }
 
 /// Read `formula_columns` — an ordered `{header: formula}` mapping.
@@ -146,6 +210,13 @@ pub fn resolve_formula_columns(
         if template.trim().is_empty() {
             return Err(value_err(format!(
                 "formula_columns['{header}'] is empty"
+            )));
+        }
+        // Placeholders expand to digits, so the structure is already final.
+        if let Some(problem) = formula_problem(&template) {
+            return Err(value_err(format!(
+                "formula_columns['{header}'] looks malformed: {problem}. \
+Formula: {template}"
             )));
         }
         if template.contains("{last}") {
@@ -385,6 +456,11 @@ pub fn resolve_layout(
             // A leading '=' marks a raw formula; anything else must name a
             // known aggregate, so a typo raises instead of writing a literal.
             let cell = if name.trim_start().starts_with('=') {
+                if let Some(problem) = formula_problem(&name) {
+                    return Err(value_err(format!(
+                        "totals_row['{column}'] looks malformed: {problem}. Formula: {name}"
+                    )));
+                }
                 TotalsCell::Formula(name)
             } else {
                 TotalsCell::Aggregate(excel_function(&name).ok_or_else(|| {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -86,6 +86,26 @@ pub struct SheetLayout {
     /// [`SheetLayout::apply_autofilter`] — the range needs the final row count,
     /// which is only known once the last row has been written.
     pub autofilter: bool,
+    /// `(column name, Excel function)` for the totals row. Also applied after
+    /// the data: the row sits below it and the formula ranges depend on how
+    /// many rows there turned out to be.
+    pub totals: Vec<(String, &'static str)>,
+    pub totals_label: Option<String>,
+    pub totals_format: Option<Format>,
+}
+
+/// Map an aggregate name to its Excel function.
+fn excel_function(name: &str) -> Option<&'static str> {
+    match name.to_ascii_lowercase().as_str() {
+        "sum" => Some("SUM"),
+        "average" | "avg" | "mean" => Some("AVERAGE"),
+        "count" => Some("COUNT"),
+        "min" => Some("MIN"),
+        "max" => Some("MAX"),
+        "product" => Some("PRODUCT"),
+        "stdev" => Some("STDEV"),
+        _ => None,
+    }
 }
 
 impl SheetLayout {
@@ -141,6 +161,67 @@ impl SheetLayout {
             .map_err(xlsx_err)?;
         Ok(())
     }
+
+    /// Write the totals row below the data. Skipped when there is no data —
+    /// a formula over an empty range (`=SUM(B2:B1)`) is not valid.
+    pub fn apply_totals(
+        &self,
+        worksheet: &mut Worksheet,
+        headers: &[String],
+        data_rows: u32,
+        py: Python,
+    ) -> PyResult<()> {
+        if (self.totals.is_empty() && self.totals_label.is_none()) || data_rows == 0 {
+            return Ok(());
+        }
+        let row = self.first_data_row() + data_rows;
+        // A1 notation is 1-based, and the data starts one row below the header.
+        let first = self.first_data_row() + 1;
+        let last = self.first_data_row() + data_rows;
+
+        let warnings = py.import("warnings")?;
+        let mut used_first_column = false;
+
+        for (name, function) in &self.totals {
+            let Some(col) = headers.iter().position(|h| h == name) else {
+                warnings.call_method1(
+                    "warn",
+                    (format!("totals_row: unknown column '{name}', skipped"),),
+                )?;
+                continue;
+            };
+            if col == 0 {
+                used_first_column = true;
+            }
+            let letter = rust_xlsxwriter::utility::column_number_to_name(col as u16);
+            let formula = format!("={function}({letter}{first}:{letter}{last})");
+            match &self.totals_format {
+                Some(fmt) => worksheet
+                    .write_formula_with_format(row, col as u16, formula.as_str(), fmt)
+                    .map_err(xlsx_err)?,
+                None => worksheet
+                    .write_formula(row, col as u16, formula.as_str())
+                    .map_err(xlsx_err)?,
+            };
+        }
+
+        if let Some(label) = &self.totals_label {
+            if used_first_column {
+                return Err(value_err(
+                    "totals_label would overwrite the totals formula in the first column; \
+drop one of them or move the aggregate to another column"
+                        .into(),
+                ));
+            }
+            match &self.totals_format {
+                Some(fmt) => worksheet
+                    .write_string_with_format(row, 0, label, fmt)
+                    .map_err(xlsx_err)?,
+                None => worksheet.write_string(row, 0, label).map_err(xlsx_err)?,
+            };
+        }
+        Ok(())
+    }
 }
 
 fn value_err(msg: String) -> PyErr {
@@ -178,7 +259,32 @@ pub fn resolve_layout(
     row_formats: Option<&Bound<'_, PyAny>>,
     banded_rows: Option<String>,
     autofilter: bool,
+    totals_row: Option<&Bound<'_, PyAny>>,
+    totals_label: Option<String>,
+    totals_format: Option<Format>,
 ) -> PyResult<SheetLayout> {
+    let mut totals = Vec::new();
+    if let Some(spec) = totals_row {
+        let dict = spec.cast::<PyDict>().map_err(|_| {
+            value_err("totals_row must be a dict of {column name: aggregate}".into())
+        })?;
+        for (key, val) in dict.iter() {
+            let column: String = key.extract().map_err(|_| {
+                value_err("totals_row keys must be column names".into())
+            })?;
+            let name: String = val.extract().map_err(|_| {
+                value_err("totals_row values must be aggregate names".into())
+            })?;
+            let function = excel_function(&name).ok_or_else(|| {
+                value_err(format!(
+                    "totals_row: unknown aggregate '{name}' for column '{column}' \
+(valid: sum, average, count, min, max, product, stdev)"
+                ))
+            })?;
+            totals.push((column, function));
+        }
+    }
+
     let mut merges = Vec::new();
     if let Some(spec) = merge_ranges {
         let list = spec.cast::<PyList>().map_err(|_| {
@@ -250,6 +356,9 @@ Merged ranges must sit strictly above the header row — raise header_row to at 
         row_formats: formats,
         band_color: banded_rows,
         autofilter,
+        totals,
+        totals_label,
+        totals_format,
     })
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -81,6 +81,11 @@ pub struct SheetLayout {
     pub row_formats: Vec<(u32, Format)>,
     /// Background colour for alternating data rows, as given by the caller.
     pub band_color: Option<String>,
+    /// Add a filter dropdown over the header row and its data. Unlike the rest
+    /// of this struct this is applied *after* the data, in
+    /// [`SheetLayout::apply_autofilter`] — the range needs the final row count,
+    /// which is only known once the last row has been written.
+    pub autofilter: bool,
 }
 
 impl SheetLayout {
@@ -113,6 +118,29 @@ impl SheetLayout {
         }
         Ok(())
     }
+
+    /// Add the filter over `header_row..=header_row + data_rows`. Safe to call
+    /// after every row is flushed: the `autoFilter` element lives in the
+    /// worksheet footer, not in the row data.
+    pub fn apply_autofilter(
+        &self,
+        worksheet: &mut Worksheet,
+        data_rows: u32,
+        num_columns: usize,
+    ) -> PyResult<()> {
+        if !self.autofilter || num_columns == 0 {
+            return Ok(());
+        }
+        worksheet
+            .autofilter(
+                self.header_row,
+                0,
+                self.header_row + data_rows,
+                (num_columns - 1) as u16,
+            )
+            .map_err(xlsx_err)?;
+        Ok(())
+    }
 }
 
 fn value_err(msg: String) -> PyErr {
@@ -142,12 +170,14 @@ fn row_keyed<T>(
 
 /// Build a [`SheetLayout`] from the Python-side arguments, rejecting anything
 /// constant-memory mode would otherwise drop without raising.
+#[allow(clippy::too_many_arguments)]
 pub fn resolve_layout(
     header_row: u32,
     merge_ranges: Option<&Bound<'_, PyAny>>,
     row_heights: Option<&Bound<'_, PyAny>>,
     row_formats: Option<&Bound<'_, PyAny>>,
     banded_rows: Option<String>,
+    autofilter: bool,
 ) -> PyResult<SheetLayout> {
     let mut merges = Vec::new();
     if let Some(spec) = merge_ranges {
@@ -219,6 +249,7 @@ Merged ranges must sit strictly above the header row — raise header_row to at 
         row_heights: heights,
         row_formats: formats,
         band_color: banded_rows,
+        autofilter,
     })
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -89,9 +89,110 @@ pub struct SheetLayout {
     /// `(column name, Excel function)` for the totals row. Also applied after
     /// the data: the row sits below it and the formula ranges depend on how
     /// many rows there turned out to be.
-    pub totals: Vec<(String, &'static str)>,
+    /// `(column name, aggregate function or raw formula template)`.
+    pub totals: Vec<(String, TotalsCell)>,
     pub totals_label: Option<String>,
     pub totals_format: Option<Format>,
+}
+
+/// A computed column: a header and a formula template appended after the data
+/// columns. `{row}` is replaced with the current row's 1-based sheet row and
+/// `{first}` with the first data row.
+///
+/// There is deliberately no `{last}`: these cells are written while the data is
+/// still streaming, so the final row is not yet known. Use `totals_row` for
+/// anything spanning the whole column — that runs after the last row.
+///
+/// The formula text is passed to `rust_xlsxwriter` verbatim, so anything Excel
+/// accepts works — nested calls, `SUMIFS`, cross-sheet references, and the 161
+/// functions the crate rewrites with an `_xlfn.` prefix or as a dynamic array.
+/// Nothing here validates the formula: a typo reaches the file unchanged and
+/// surfaces when a spreadsheet opens it.
+pub struct FormulaColumn {
+    pub header: String,
+    pub template: String,
+}
+
+impl FormulaColumn {
+    /// Substitute the row placeholders for one data row.
+    pub fn render(&self, row: u32, first: u32) -> String {
+        let mut out = self.template.clone();
+        if out.contains("{row}") {
+            out = out.replace("{row}", &row.to_string());
+        }
+        if out.contains("{first}") {
+            out = out.replace("{first}", &first.to_string());
+        }
+        out
+    }
+}
+
+/// Read `formula_columns` — an ordered `{header: formula}` mapping.
+pub fn resolve_formula_columns(
+    spec: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Vec<FormulaColumn>> {
+    let Some(spec) = spec else { return Ok(Vec::new()) };
+    let dict = spec.cast::<PyDict>().map_err(|_| {
+        value_err("formula_columns must be a dict of {header: formula}".into())
+    })?;
+    let mut out = Vec::with_capacity(dict.len());
+    for (key, val) in dict.iter() {
+        let header: String = key.extract().map_err(|_| {
+            value_err("formula_columns keys must be header names".into())
+        })?;
+        let template: String = val.extract().map_err(|_| {
+            value_err(format!("formula_columns['{header}'] must be a formula string"))
+        })?;
+        if template.trim().is_empty() {
+            return Err(value_err(format!(
+                "formula_columns['{header}'] is empty"
+            )));
+        }
+        if template.contains("{last}") {
+            return Err(value_err(format!(
+                "formula_columns['{header}'] uses {{last}}, but the last data row is not \
+known while rows are still streaming. Use totals_row for a whole-column formula, \
+or {{row}} for a per-row one."
+            )));
+        }
+        out.push(FormulaColumn { header, template });
+    }
+    Ok(out)
+}
+
+/// Write the formula cells for one data row, starting at `first_col`.
+pub fn write_formula_row(
+    worksheet: &mut Worksheet,
+    columns: &[FormulaColumn],
+    first_col: u16,
+    row: u32,
+    first_data_row: u32,
+    fmt: Option<&Format>,
+) -> PyResult<()> {
+    for (offset, column) in columns.iter().enumerate() {
+        // A1 notation is 1-based.
+        let formula = column.render(row + 1, first_data_row + 1);
+        let col = first_col + offset as u16;
+        match fmt {
+            Some(f) => worksheet
+                .write_formula_with_format(row, col, formula.as_str(), f)
+                .map_err(xlsx_err)?,
+            None => worksheet
+                .write_formula(row, col, formula.as_str())
+                .map_err(xlsx_err)?,
+        };
+    }
+    Ok(())
+}
+
+/// What to write in one totals cell.
+pub enum TotalsCell {
+    /// A named aggregate, expanded to `=FUNC(range)` over the column.
+    Aggregate(&'static str),
+    /// A caller-supplied formula. `{col}` is the column letter, `{first}` and
+    /// `{last}` the first and last data rows — all known by the time the totals
+    /// row is written.
+    Formula(String),
 }
 
 /// Map an aggregate name to its Excel function.
@@ -179,14 +280,6 @@ impl SheetLayout {
         let first = self.first_data_row() + 1;
         let last = self.first_data_row() + data_rows;
 
-        // We don't calculate the formulas, and the crate's default cached
-        // result is 0 — a plausible-looking wrong total for any reader that
-        // trusts the cache (`pandas.read_excel`, `openpyxl` with
-        // `data_only=True`). An empty result reads back as "not computed"
-        // instead, and per rust_xlsxwriter's docs it is also what forces
-        // LibreOffice to recalculate rather than display the stale 0.
-        worksheet.set_formula_result_default("");
-
         let warnings = py.import("warnings")?;
         let mut used_first_column = false;
 
@@ -202,7 +295,13 @@ impl SheetLayout {
                 used_first_column = true;
             }
             let letter = rust_xlsxwriter::utility::column_number_to_name(col as u16);
-            let formula = format!("={function}({letter}{first}:{letter}{last})");
+            let formula = match function {
+                TotalsCell::Aggregate(f) => format!("={f}({letter}{first}:{letter}{last})"),
+                TotalsCell::Formula(t) => t
+                    .replace("{col}", &letter)
+                    .replace("{first}", &first.to_string())
+                    .replace("{last}", &last.to_string()),
+            };
             match &self.totals_format {
                 Some(fmt) => worksheet
                     .write_formula_with_format(row, col as u16, formula.as_str(), fmt)
@@ -281,15 +380,21 @@ pub fn resolve_layout(
                 value_err("totals_row keys must be column names".into())
             })?;
             let name: String = val.extract().map_err(|_| {
-                value_err("totals_row values must be aggregate names".into())
+                value_err("totals_row values must be aggregate names or formulas".into())
             })?;
-            let function = excel_function(&name).ok_or_else(|| {
-                value_err(format!(
-                    "totals_row: unknown aggregate '{name}' for column '{column}' \
-(valid: sum, average, count, min, max, product, stdev)"
-                ))
-            })?;
-            totals.push((column, function));
+            // A leading '=' marks a raw formula; anything else must name a
+            // known aggregate, so a typo raises instead of writing a literal.
+            let cell = if name.trim_start().starts_with('=') {
+                TotalsCell::Formula(name)
+            } else {
+                TotalsCell::Aggregate(excel_function(&name).ok_or_else(|| {
+                    value_err(format!(
+                        "totals_row: unknown aggregate '{name}' for column '{column}' \
+(valid: sum, average, count, min, max, product, stdev; or a formula starting with '=')"
+                    ))
+                })?)
+            };
+            totals.push((column, cell));
         }
     }
 

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -454,6 +454,7 @@ fn write_worksheet_content(
     }
 
     layout.apply_autofilter(worksheet, data_rows, final_headers.len())?;
+    layout.apply_totals(worksheet, &final_headers, data_rows, py)?;
 
     if freeze_row.is_some() || freeze_col.is_some() {
         worksheet
@@ -753,7 +754,7 @@ fn keyed_get<'py>(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = None, url_columns = None))]
+#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = None, url_columns = None, totals_row = None, totals_label = None, totals_format = None))]
 pub fn write_worksheets(
     py: Python,
     records_with_sheet_name: Vec<(String, WorksheetData)>,
@@ -777,6 +778,9 @@ pub fn write_worksheets(
     banded_rows: Option<Bound<'_, pyo3::types::PyDict>>,
     autofilter: Option<Bound<'_, pyo3::types::PyDict>>,
     url_columns: Option<Bound<'_, pyo3::types::PyDict>>,
+    totals_row: Option<Bound<'_, pyo3::types::PyDict>>,
+    totals_label: Option<Bound<'_, pyo3::types::PyDict>>,
+    totals_format: Option<Bound<'_, pyo3::types::PyDict>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     for (sheet_name, records) in records_with_sheet_name {
@@ -831,6 +835,15 @@ pub fn write_worksheets(
                 .map(|v| v.extract::<bool>())
                 .transpose()?
                 .unwrap_or(false),
+            keyed_get(totals_row.as_ref(), &sheet_name)?.as_ref(),
+            keyed_get(totals_label.as_ref(), &sheet_name)?
+                .filter(|v| !v.is_none())
+                .map(|v| v.extract())
+                .transpose()?,
+            match keyed_get(totals_format.as_ref(), &sheet_name)? {
+                Some(v) if !v.is_none() => Some(v.extract::<crate::format::Format>()?.inner),
+                _ => None,
+            },
         )?;
 
         let sheet_urls: Option<Vec<String>> = keyed_get(url_columns.as_ref(), &sheet_name)?
@@ -865,7 +878,7 @@ pub fn write_worksheets(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = false, url_columns = None))]
+#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = false, url_columns = None, totals_row = None, totals_label = None, totals_format = None))]
 pub fn write_worksheet(
     py: Python,
     records: WorksheetData,
@@ -891,6 +904,9 @@ pub fn write_worksheet(
     banded_rows: Option<String>,
     autofilter: bool,
     url_columns: Option<Vec<String>>,
+    totals_row: Option<Bound<'_, PyAny>>,
+    totals_label: Option<String>,
+    totals_format: Option<Bound<'_, crate::format::Format>>,
 ) -> PyResult<()> {
     let layout = crate::helpers::resolve_layout(
         header_row,
@@ -899,6 +915,9 @@ pub fn write_worksheet(
         row_formats.as_ref(),
         banded_rows,
         autofilter,
+        totals_row.as_ref(),
+        totals_label,
+        totals_format.map(|f| f.borrow().inner.clone()),
     )?;
     let mut workbook = Workbook::new();
     let mut worksheet = if dedupe_strings {

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -197,6 +197,8 @@ fn write_worksheet_content(
     let bold_fmt = Format::new().set_bold();
     let mut datetime_cols_set: HashSet<u16> = HashSet::new();
     let mut final_headers: Vec<String> = Vec::new();
+    // Number of data rows written, needed for the autofilter range.
+    let mut data_rows: u32 = 0;
 
     // Merges, row heights and row formats must all land before the first data
     // cell — constant-memory mode cannot revisit a flushed row.
@@ -266,6 +268,7 @@ fn write_worksheet_content(
 
                     current_row += batch.num_rows() as u32;
                 }
+                data_rows = current_row - layout.first_data_row();
                 Ok(())
             })();
 
@@ -380,6 +383,7 @@ fn write_worksheet_content(
                             }
                         }
                     }
+                    data_rows = row_idx as u32 + 1;
                 }
             }
         }
@@ -390,6 +394,7 @@ fn write_worksheet_content(
                 py,
                 df,
                 &mut final_headers,
+                &mut data_rows,
                 column_formats,
                 float_fmt.as_ref(),
                 &datetime_fmt,
@@ -414,6 +419,7 @@ fn write_worksheet_content(
                 py,
                 df,
                 &mut final_headers,
+                &mut data_rows,
                 column_formats,
                 float_fmt.as_ref(),
                 &datetime_fmt,
@@ -429,6 +435,8 @@ fn write_worksheet_content(
             )?;
         }
     }
+
+    layout.apply_autofilter(worksheet, data_rows, final_headers.len())?;
 
     if freeze_row.is_some() || freeze_col.is_some() {
         worksheet
@@ -625,6 +633,7 @@ fn write_dataframe<C>(
     py: Python,
     df: &Py<PyAny>,
     final_headers: &mut Vec<String>,
+    data_rows: &mut u32,
     column_formats: Option<&Bound<'_, PyAny>>,
     float_fmt: Option<&Format>,
     datetime_fmt: &Format,
@@ -672,6 +681,7 @@ where
     }
 
     let nrows: usize = df.call_method0(py, "__len__")?.extract(py)?;
+    *data_rows = nrows as u32;
 
     // Auto datetime column formats first, then explicit column_formats
     // override (constant memory: BEFORE writing data rows).
@@ -720,7 +730,7 @@ fn keyed_get<'py>(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None))]
+#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = None))]
 pub fn write_worksheets(
     py: Python,
     records_with_sheet_name: Vec<(String, WorksheetData)>,
@@ -742,6 +752,7 @@ pub fn write_worksheets(
     row_heights: Option<Bound<'_, pyo3::types::PyDict>>,
     row_formats: Option<Bound<'_, pyo3::types::PyDict>>,
     banded_rows: Option<Bound<'_, pyo3::types::PyDict>>,
+    autofilter: Option<Bound<'_, pyo3::types::PyDict>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     for (sheet_name, records) in records_with_sheet_name {
@@ -792,6 +803,10 @@ pub fn write_worksheets(
             keyed_get(row_heights.as_ref(), &sheet_name)?.as_ref(),
             keyed_get(row_formats.as_ref(), &sheet_name)?.as_ref(),
             sheet_band,
+            keyed_get(autofilter.as_ref(), &sheet_name)?
+                .map(|v| v.extract::<bool>())
+                .transpose()?
+                .unwrap_or(false),
         )?;
 
         write_worksheet_content(
@@ -820,7 +835,7 @@ pub fn write_worksheets(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None))]
+#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = false))]
 pub fn write_worksheet(
     py: Python,
     records: WorksheetData,
@@ -844,6 +859,7 @@ pub fn write_worksheet(
     row_heights: Option<Bound<'_, PyAny>>,
     row_formats: Option<Bound<'_, PyAny>>,
     banded_rows: Option<String>,
+    autofilter: bool,
 ) -> PyResult<()> {
     let layout = crate::helpers::resolve_layout(
         header_row,
@@ -851,6 +867,7 @@ pub fn write_worksheet(
         row_heights.as_ref(),
         row_formats.as_ref(),
         banded_rows,
+        autofilter,
     )?;
     let mut workbook = Workbook::new();
     let mut worksheet = if dedupe_strings {

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -194,6 +194,7 @@ fn write_worksheet_content(
     header_format: Option<&crate::format::Format>,
     layout: &crate::helpers::SheetLayout,
     url_columns: Option<&Vec<String>>,
+    formula_columns: Option<&Bound<'_, PyAny>>,
     py: Python,
 ) -> PyResult<()> {
     let float_fmt = float_format.map(|s| Format::new().set_num_format(s));
@@ -210,6 +211,14 @@ fn write_worksheet_content(
     // Merges, row heights and row formats must all land before the first data
     // cell — constant-memory mode cannot revisit a flushed row.
     layout.apply(worksheet)?;
+    let formula_cols = crate::helpers::resolve_formula_columns(formula_columns)?;
+    // Applies to every formula this sheet writes, so it must be set before any
+    // of them. The crate's default cached result is 0, which readers that trust
+    // the cache take at face value — `pandas.read_excel` reports 0, and
+    // LibreOffice displays 0 instead of recalculating. An empty result reads
+    // back as "not computed" and forces a recalculation on open.
+    worksheet.set_formula_result_default("");
+    let first_data_row = layout.first_data_row();
     let header_row = layout.header_row;
     let banding = layout.band_color.is_some();
 
@@ -224,6 +233,10 @@ fn write_worksheet_content(
                     .iter()
                     .map(|f| f.name().to_string())
                     .collect();
+                for fc in &formula_cols {
+                    final_headers.push(fc.header.clone());
+                }
+                let n_data_cols = final_headers.len() - formula_cols.len();
                 write_all_headers(
                     worksheet,
                     header_row,
@@ -274,6 +287,8 @@ fn write_worksheet_content(
                         banded.as_ref(),
                         layout,
                         &url_cols,
+                        &formula_cols,
+                        n_data_cols,
                     )?;
 
                     current_row += batch.num_rows() as u32;
@@ -313,6 +328,7 @@ fn write_worksheet_content(
                     Option<crate::format::RowPalette>,
                 )> = None;
                 let mut url_cols: Vec<bool> = Vec::new();
+                let mut n_data_cols: usize = 0;
 
                 for (row_idx, row_res) in rows.enumerate() {
                     let row_obj = row_res?;
@@ -326,6 +342,9 @@ fn write_worksheet_content(
                         for key in row_dict.keys().iter() {
                             headers.push(key.extract::<String>()?);
                         }
+                        for fc in &formula_cols {
+                            headers.push(fc.header.clone());
+                        }
                         write_all_headers(
                             worksheet,
                             header_row,
@@ -337,6 +356,7 @@ fn write_worksheet_content(
                         )?;
                         col_types.resize(headers.len(), ColType::Unknown);
                         final_headers = headers.clone();
+                        n_data_cols = headers.len() - formula_cols.len();
                         // Resolve per-column formats ONCE and keep them for the whole loop.
                         // Apply set_column_format BEFORE writing data rows (constant memory mode).
                         let col_formats =
@@ -398,6 +418,16 @@ fn write_worksheet_content(
                             }
                         }
                     }
+                    if !formula_cols.is_empty() {
+                        crate::helpers::write_formula_row(
+                            worksheet,
+                            &formula_cols,
+                            n_data_cols as u16,
+                            row_u32,
+                            first_data_row,
+                            None,
+                        )?;
+                    }
                     data_rows = row_idx as u32 + 1;
                 }
             }
@@ -420,6 +450,7 @@ fn write_worksheet_content(
                 header_format,
                 layout,
                 url_columns,
+                &formula_cols,
                 "__getitem__",
                 "tolist",
                 |dtype| {
@@ -446,6 +477,7 @@ fn write_worksheet_content(
                 header_format,
                 layout,
                 url_columns,
+                &formula_cols,
                 "get_column",
                 "to_list",
                 |dtype| Ok(polars_kind(&dtype.to_string())),
@@ -527,6 +559,8 @@ fn write_df_rows<F>(
     banded: Option<&crate::format::RowPalette>,
     layout: &crate::helpers::SheetLayout,
     url_cols: &[bool],
+    formula_cols: &[crate::helpers::FormulaColumn],
+    n_data_cols: usize,
 ) -> PyResult<()>
 where
     F: Fn(usize) -> ScalarKind,
@@ -635,6 +669,16 @@ where
                 }
             }
         }
+        if !formula_cols.is_empty() {
+            crate::helpers::write_formula_row(
+                worksheet,
+                formula_cols,
+                n_data_cols as u16,
+                row_u32,
+                layout.first_data_row(),
+                None,
+            )?;
+        }
     }
     Ok(())
 }
@@ -664,6 +708,7 @@ fn write_dataframe<C>(
     header_format: Option<&crate::format::Format>,
     layout: &crate::helpers::SheetLayout,
     url_columns: Option<&Vec<String>>,
+    formula_cols: &[crate::helpers::FormulaColumn],
     get_column_method: &str,
     to_list_method: &str,
     classify_dtype: C,
@@ -672,7 +717,11 @@ where
     C: Fn(&Bound<'_, PyAny>) -> PyResult<ScalarKind>,
 {
     let headers: Vec<String> = df.getattr(py, "columns")?.extract(py)?;
+    let n_data_cols = headers.len();
     *final_headers = headers.clone();
+    for fc in formula_cols {
+        final_headers.push(fc.header.clone());
+    }
     let dtypes = df.getattr(py, "dtypes")?;
     let dtypes_list: Vec<Bound<'_, PyAny>> =
         dtypes.bind(py).try_iter()?.collect::<Result<Vec<_>, _>>()?;
@@ -680,7 +729,7 @@ where
     write_all_headers(
         worksheet,
         layout.header_row,
-        &headers,
+        final_headers,
         bold_headers,
         bold_fmt,
         index_columns,
@@ -736,6 +785,8 @@ where
         banded.as_ref(),
         layout,
         &url_cols,
+        formula_cols,
+        n_data_cols,
     )
 }
 
@@ -754,7 +805,7 @@ fn keyed_get<'py>(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = None, url_columns = None, totals_row = None, totals_label = None, totals_format = None))]
+#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = None, url_columns = None, totals_row = None, totals_label = None, totals_format = None, formula_columns = None))]
 pub fn write_worksheets(
     py: Python,
     records_with_sheet_name: Vec<(String, WorksheetData)>,
@@ -781,6 +832,7 @@ pub fn write_worksheets(
     totals_row: Option<Bound<'_, pyo3::types::PyDict>>,
     totals_label: Option<Bound<'_, pyo3::types::PyDict>>,
     totals_format: Option<Bound<'_, pyo3::types::PyDict>>,
+    formula_columns: Option<Bound<'_, pyo3::types::PyDict>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     for (sheet_name, records) in records_with_sheet_name {
@@ -868,6 +920,7 @@ pub fn write_worksheets(
             sheet_hdr_fmt.as_ref(),
             &layout,
             sheet_urls.as_ref(),
+            keyed_get(formula_columns.as_ref(), &sheet_name)?.as_ref(),
             py,
         )?;
     }
@@ -878,7 +931,7 @@ pub fn write_worksheets(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = false, url_columns = None, totals_row = None, totals_label = None, totals_format = None))]
+#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = false, url_columns = None, totals_row = None, totals_label = None, totals_format = None, formula_columns = None))]
 pub fn write_worksheet(
     py: Python,
     records: WorksheetData,
@@ -907,6 +960,7 @@ pub fn write_worksheet(
     totals_row: Option<Bound<'_, PyAny>>,
     totals_label: Option<String>,
     totals_format: Option<Bound<'_, crate::format::Format>>,
+    formula_columns: Option<Bound<'_, PyAny>>,
 ) -> PyResult<()> {
     let layout = crate::helpers::resolve_layout(
         header_row,
@@ -951,6 +1005,7 @@ pub fn write_worksheet(
         hdr_ref,
         &layout,
         url_columns.as_ref(),
+        formula_columns.as_ref(),
         py,
     )?;
 

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -8,7 +8,8 @@ use crate::cell::{classify_and_write, try_cached, CellWriter};
 use crate::data_types::{FreezePanesConfig, WorksheetData};
 use crate::helpers::{
     py_date_to_excel, py_datetime_to_excel, save_workbook, write_all_headers, write_bool_opt,
-    write_datetime_opt, write_num, write_number_opt, write_string_opt, ColType,
+    write_datetime_opt, write_num, write_number_opt, write_string_opt, write_url_or_text,
+    ColType,
 };
 use crate::utils::ensure_valid_sheet_name;
 
@@ -37,6 +38,8 @@ struct ExcelCell<'a> {
     /// one-shot column format — a column format is fixed for every row and so
     /// cannot alternate.
     per_cell_datetime: bool,
+    /// This column was listed in `url_columns`, so strings become links.
+    is_url: bool,
 }
 
 impl ExcelCell<'_> {
@@ -67,6 +70,9 @@ impl ExcelCell<'_> {
     }
 
     fn put_string(&mut self, s: &str) -> PyResult<()> {
+        if self.is_url && !s.is_empty() {
+            return write_url_or_text(self.worksheet, self.row, self.col, s, self.text_fmt);
+        }
         match self.text_fmt {
             Some(fmt) => self
                 .worksheet
@@ -187,6 +193,7 @@ fn write_worksheet_content(
     column_formats: Option<&Bound<'_, PyAny>>,
     header_format: Option<&crate::format::Format>,
     layout: &crate::helpers::SheetLayout,
+    url_columns: Option<&Vec<String>>,
     py: Python,
 ) -> PyResult<()> {
     let float_fmt = float_format.map(|s| Format::new().set_num_format(s));
@@ -241,6 +248,8 @@ fn write_worksheet_content(
                     &datetime_fmt,
                     layout.band_color.as_deref(),
                 )?;
+                let url_cols =
+                    crate::helpers::resolve_url_columns(url_columns, &final_headers, py)?;
 
                 for batch_result in reader {
                     let batch = batch_result.map_err(crate::arrow_ffi::batch_read_err)?;
@@ -264,6 +273,7 @@ fn write_worksheet_content(
                         &plain,
                         banded.as_ref(),
                         layout,
+                        &url_cols,
                     )?;
 
                     current_row += batch.num_rows() as u32;
@@ -302,6 +312,7 @@ fn write_worksheet_content(
                     crate::format::RowPalette,
                     Option<crate::format::RowPalette>,
                 )> = None;
+                let mut url_cols: Vec<bool> = Vec::new();
 
                 for (row_idx, row_res) in rows.enumerate() {
                     let row_obj = row_res?;
@@ -337,6 +348,8 @@ fn write_worksheet_content(
                             &datetime_fmt,
                             layout.band_color.as_deref(),
                         )?);
+                        url_cols =
+                            crate::helpers::resolve_url_columns(url_columns, &final_headers, py)?;
                         headers_written = true;
                     }
 
@@ -362,6 +375,7 @@ fn write_worksheet_content(
                         datetime_cols_set: &mut datetime_cols_set,
                         col_override: None,
                         per_cell_datetime: banding,
+                        is_url: false,
                     };
 
                     // Iterate the dict directly (insertion order == header order)
@@ -375,6 +389,7 @@ fn write_worksheet_content(
                         sink.col = col as u16;
                         // Column format override: wins over float_fmt / datetime_fmt.
                         sink.col_override = pal.col(col);
+                        sink.is_url = url_cols.get(col).copied().unwrap_or(false);
 
                         if !try_cached(&value, cached, &mut sink)? {
                             let detected = classify_and_write(&value, &mut sink)?;
@@ -404,6 +419,7 @@ fn write_worksheet_content(
                 index_columns,
                 header_format,
                 layout,
+                url_columns,
                 "__getitem__",
                 "tolist",
                 |dtype| {
@@ -429,6 +445,7 @@ fn write_worksheet_content(
                 index_columns,
                 header_format,
                 layout,
+                url_columns,
                 "get_column",
                 "to_list",
                 |dtype| Ok(polars_kind(&dtype.to_string())),
@@ -508,6 +525,7 @@ fn write_df_rows<F>(
     plain: &crate::format::RowPalette,
     banded: Option<&crate::format::RowPalette>,
     layout: &crate::helpers::SheetLayout,
+    url_cols: &[bool],
 ) -> PyResult<()>
 where
     F: Fn(usize) -> ScalarKind,
@@ -610,6 +628,7 @@ where
                         datetime_cols_set: &mut *datetime_cols_set,
                         col_override,
                         per_cell_datetime: banding,
+                        is_url: url_cols.get(col_idx).copied().unwrap_or(false),
                     };
                     classify_and_write(&item, &mut sink)?;
                 }
@@ -643,6 +662,7 @@ fn write_dataframe<C>(
     index_columns: Option<&Vec<String>>,
     header_format: Option<&crate::format::Format>,
     layout: &crate::helpers::SheetLayout,
+    url_columns: Option<&Vec<String>>,
     get_column_method: &str,
     to_list_method: &str,
     classify_dtype: C,
@@ -702,6 +722,8 @@ where
         layout.band_color.as_deref(),
     )?;
 
+    let url_cols = crate::helpers::resolve_url_columns(url_columns, final_headers, py)?;
+
     write_df_rows(
         worksheet,
         py,
@@ -712,6 +734,7 @@ where
         &plain,
         banded.as_ref(),
         layout,
+        &url_cols,
     )
 }
 
@@ -730,7 +753,7 @@ fn keyed_get<'py>(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = None))]
+#[pyo3(signature = (records_with_sheet_name, file_name, password = None, freeze_panes = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = None, header_row = None, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = None, url_columns = None))]
 pub fn write_worksheets(
     py: Python,
     records_with_sheet_name: Vec<(String, WorksheetData)>,
@@ -753,6 +776,7 @@ pub fn write_worksheets(
     row_formats: Option<Bound<'_, pyo3::types::PyDict>>,
     banded_rows: Option<Bound<'_, pyo3::types::PyDict>>,
     autofilter: Option<Bound<'_, pyo3::types::PyDict>>,
+    url_columns: Option<Bound<'_, pyo3::types::PyDict>>,
 ) -> PyResult<()> {
     let mut workbook = Workbook::new();
     for (sheet_name, records) in records_with_sheet_name {
@@ -809,6 +833,11 @@ pub fn write_worksheets(
                 .unwrap_or(false),
         )?;
 
+        let sheet_urls: Option<Vec<String>> = keyed_get(url_columns.as_ref(), &sheet_name)?
+            .filter(|v| !v.is_none())
+            .map(|v| v.extract())
+            .transpose()?;
+
         write_worksheet_content(
             &mut worksheet,
             &records,
@@ -825,6 +854,7 @@ pub fn write_worksheets(
             sheet_col_fmts.as_ref(),
             sheet_hdr_fmt.as_ref(),
             &layout,
+            sheet_urls.as_ref(),
             py,
         )?;
     }
@@ -835,7 +865,7 @@ pub fn write_worksheets(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = false))]
+#[pyo3(signature = (records, file_name, sheet_name = None, password = None, freeze_row = None, freeze_col = None, float_format = None, datetime_format = None, index_columns = None, autofit = true, bold_headers = false, column_width = None, column_widths = None, column_formats = None, header_format = None, dedupe_strings = false, header_row = 0, merge_ranges = None, row_heights = None, row_formats = None, banded_rows = None, autofilter = false, url_columns = None))]
 pub fn write_worksheet(
     py: Python,
     records: WorksheetData,
@@ -860,6 +890,7 @@ pub fn write_worksheet(
     row_formats: Option<Bound<'_, PyAny>>,
     banded_rows: Option<String>,
     autofilter: bool,
+    url_columns: Option<Vec<String>>,
 ) -> PyResult<()> {
     let layout = crate::helpers::resolve_layout(
         header_row,
@@ -900,6 +931,7 @@ pub fn write_worksheet(
         column_formats.as_ref(),
         hdr_ref,
         &layout,
+        url_columns.as_ref(),
         py,
     )?;
 

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -792,6 +792,34 @@ where
 
 /// Resolve a per-sheet value from a dict keyed by sheet name, falling back
 /// to the `"general"` key. Returns the matching Python value, if any.
+/// [`keyed_get`] plus extraction, treating an explicit `None` as absent.
+/// Callers that want a Rust value rather than the raw object use this so the
+/// `filter`/`map`/`transpose` dance is written once.
+fn keyed_extract<'py, T>(
+    dict: Option<&Bound<'py, pyo3::types::PyDict>>,
+    sheet: &str,
+) -> PyResult<Option<T>>
+where
+    T: for<'a> FromPyObject<'a, 'py, Error = PyErr>,
+{
+    keyed_get(dict, sheet)?
+        .filter(|v| !v.is_none())
+        .map(|v| v.extract())
+        .transpose()
+}
+
+/// [`keyed_extract`] for `Format`, which has its own `FromPyObject` error type
+/// and so does not fit that generic bound.
+fn keyed_format(
+    dict: Option<&Bound<'_, pyo3::types::PyDict>>,
+    sheet: &str,
+) -> PyResult<Option<crate::format::Format>> {
+    match keyed_get(dict, sheet)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract()?)),
+        _ => Ok(None),
+    }
+}
+
 fn keyed_get<'py>(
     dict: Option<&Bound<'py, pyo3::types::PyDict>>,
     sheet: &str,
@@ -838,9 +866,7 @@ pub fn write_worksheets(
     for (sheet_name, records) in records_with_sheet_name {
         ensure_valid_sheet_name(&sheet_name)?;
 
-        let dedupe = keyed_get(dedupe_strings.as_ref(), &sheet_name)?
-            .map(|v| v.extract::<bool>())
-            .transpose()?
+        let dedupe = keyed_extract::<bool>(dedupe_strings.as_ref(), &sheet_name)?
             .unwrap_or(false);
 
         let mut worksheet = if dedupe {
@@ -855,53 +881,30 @@ pub fn write_worksheets(
             .map(|c| c.resolve(&sheet_name))
             .unwrap_or_default();
 
-        let sheet_uniform: Option<f64> = keyed_get(column_width.as_ref(), &sheet_name)?
-            .map(|v| v.extract())
-            .transpose()?;
+        let sheet_uniform = keyed_extract::<f64>(column_width.as_ref(), &sheet_name)?;
         let sheet_spec: Option<Bound<'_, PyAny>> =
             keyed_get(column_widths.as_ref(), &sheet_name)?;
 
         let sheet_col_fmts: Option<Bound<'_, PyAny>> =
             keyed_get(column_formats.as_ref(), &sheet_name)?;
-        let sheet_hdr_fmt: Option<crate::format::Format> =
-            match keyed_get(header_format.as_ref(), &sheet_name)? {
-                Some(v) => Some(v.extract()?),
-                None => None,
-            };
+        let sheet_hdr_fmt = keyed_format(header_format.as_ref(), &sheet_name)?;
 
-        let sheet_header_row: u32 = keyed_get(header_row.as_ref(), &sheet_name)?
-            .map(|v| v.extract())
-            .transpose()?
-            .unwrap_or(0);
-        let sheet_band: Option<String> = keyed_get(banded_rows.as_ref(), &sheet_name)?
-            .filter(|v| !v.is_none())
-            .map(|v| v.extract())
-            .transpose()?;
+        let sheet_header_row =
+            keyed_extract::<u32>(header_row.as_ref(), &sheet_name)?.unwrap_or(0);
+        let sheet_band = keyed_extract::<String>(banded_rows.as_ref(), &sheet_name)?;
         let layout = crate::helpers::resolve_layout(
             sheet_header_row,
             keyed_get(merge_ranges.as_ref(), &sheet_name)?.as_ref(),
             keyed_get(row_heights.as_ref(), &sheet_name)?.as_ref(),
             keyed_get(row_formats.as_ref(), &sheet_name)?.as_ref(),
             sheet_band,
-            keyed_get(autofilter.as_ref(), &sheet_name)?
-                .map(|v| v.extract::<bool>())
-                .transpose()?
-                .unwrap_or(false),
+            keyed_extract::<bool>(autofilter.as_ref(), &sheet_name)?.unwrap_or(false),
             keyed_get(totals_row.as_ref(), &sheet_name)?.as_ref(),
-            keyed_get(totals_label.as_ref(), &sheet_name)?
-                .filter(|v| !v.is_none())
-                .map(|v| v.extract())
-                .transpose()?,
-            match keyed_get(totals_format.as_ref(), &sheet_name)? {
-                Some(v) if !v.is_none() => Some(v.extract::<crate::format::Format>()?.inner),
-                _ => None,
-            },
+            keyed_extract::<String>(totals_label.as_ref(), &sheet_name)?,
+            keyed_format(totals_format.as_ref(), &sheet_name)?.map(|f| f.inner),
         )?;
 
-        let sheet_urls: Option<Vec<String>> = keyed_get(url_columns.as_ref(), &sheet_name)?
-            .filter(|v| !v.is_none())
-            .map(|v| v.extract())
-            .transpose()?;
+        let sheet_urls = keyed_extract::<Vec<String>>(url_columns.as_ref(), &sheet_name)?;
 
         write_worksheet_content(
             &mut worksheet,

--- a/tests/test_autofilter.py
+++ b/tests/test_autofilter.py
@@ -1,0 +1,128 @@
+"""Autofilter — filter dropdowns over the header row and its data.
+
+The range depends on the final row count, which constant-memory mode only
+knows once the last row is flushed, so it is applied after the data. These
+tests pin the computed range for every data path and every row offset.
+"""
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, write_worksheet, write_worksheets
+
+
+def _records(n=5):
+    return [{"name": f"n{i}", "score": i * 1.5, "count": i} for i in range(n)]
+
+
+def _ref(path, sheet=None):
+    wb = openpyxl.load_workbook(path)
+    ws = wb[sheet] if sheet else wb.active
+    return ws.auto_filter.ref
+
+
+def test_off_by_default(tmp_path):
+    path = tmp_path / "off.xlsx"
+    write_worksheet(_records(), str(path))
+    assert _ref(path) is None
+
+
+def test_covers_header_and_all_data_rows(tmp_path):
+    path = tmp_path / "on.xlsx"
+    write_worksheet(_records(5), str(path), autofilter=True)
+    # 3 columns, header on row 1 plus 5 data rows.
+    assert _ref(path) == "A1:C6"
+
+
+def test_range_follows_header_row(tmp_path):
+    path = tmp_path / "offset.xlsx"
+    write_worksheet(
+        _records(4),
+        str(path),
+        header_row=2,
+        merge_ranges=[(0, 0, 0, 2, "Banner")],
+        autofilter=True,
+    )
+    # Header on sheet row 3, 4 data rows below it.
+    assert _ref(path) == "A3:C7"
+
+
+def test_empty_records_filters_header_only(tmp_path):
+    path = tmp_path / "empty.xlsx"
+    write_worksheet([], str(path), autofilter=True)
+    # No headers were written, so there is nothing to filter.
+    assert _ref(path) is None
+
+
+def test_single_row(tmp_path):
+    path = tmp_path / "one.xlsx"
+    write_worksheet(_records(1), str(path), autofilter=True)
+    assert _ref(path) == "A1:C2"
+
+
+def test_combines_with_freeze_and_banding(tmp_path):
+    path = tmp_path / "combo.xlsx"
+    write_worksheet(
+        _records(4),
+        str(path),
+        freeze_row=1,
+        banded_rows="#F2F2F2",
+        autofilter=True,
+    )
+    ws = openpyxl.load_workbook(path).active
+    assert ws.auto_filter.ref == "A1:C5"
+    assert ws.freeze_panes == "A2"
+    assert ws.cell(row=3, column=1).fill.fgColor.rgb == "FFF2F2F2"
+
+
+@pytest.mark.parametrize("frame", ["pandas", "polars"])
+def test_dataframe_paths(tmp_path, frame):
+    mod = pytest.importorskip(frame)
+    df = mod.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / f"{frame}.xlsx"
+    write_worksheet(df, str(path), autofilter=True)
+    assert _ref(path) == "A1:B4"
+
+
+def test_dataframe_fallback_path(tmp_path):
+    """The non-Arrow writer reports its row count separately."""
+    from tests.test_row_layout import _FakeFrame
+
+    df = _FakeFrame({"a": [1, 2, 3, 4]}, kinds=["i"])
+    path = tmp_path / "fallback.xlsx"
+    write_worksheet(df, str(path), autofilter=True)
+    assert _ref(path) == "A1:A5"
+
+
+def test_multi_sheet_is_per_sheet(tmp_path):
+    path = tmp_path / "multi.xlsx"
+    write_worksheets(
+        [("Filtered", _records(3)), ("Plain", _records(3))],
+        str(path),
+        autofilter={"Filtered": True},
+    )
+    assert _ref(path, "Filtered") == "A1:C4"
+    assert _ref(path, "Plain") is None
+
+
+def test_multi_sheet_general_key(tmp_path):
+    path = tmp_path / "general.xlsx"
+    write_worksheets(
+        [("A", _records(2)), ("B", _records(3))],
+        str(path),
+        autofilter={"general": True},
+    )
+    assert _ref(path, "A") == "A1:C3"
+    assert _ref(path, "B") == "A1:C4"
+
+
+def test_fastexcel_builder(tmp_path):
+    path = tmp_path / "builder.xlsx"
+    FastExcel(str(path)).sheet("S", _records(6), autofilter=True).save()
+    assert _ref(path, "S") == "A1:C7"
+
+
+def test_csv_warns_that_autofilter_is_dropped(tmp_path):
+    path = tmp_path / "o.csv"
+    with pytest.warns(UserWarning, match="autofilter"):
+        FastExcel(str(path)).sheet("S", _records(2), autofilter=True).save()

--- a/tests/test_csv_ignored_options.py
+++ b/tests/test_csv_ignored_options.py
@@ -1,0 +1,130 @@
+"""CSV/TSV output must say what it is throwing away.
+
+Every Excel-only option is silently discarded on the CSV path — the Rust
+``write_csv`` only takes a delimiter and the formula guard. Swapping a target
+from ``.xlsx`` to ``.csv`` therefore drops all formatting, so the builder warns
+instead of quietly producing a plain file.
+"""
+
+import contextlib
+import warnings
+
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, Format
+
+ROWS = [{"a": 1.23456, "b": "x"}]
+
+
+@contextlib.contextmanager
+def _no_warnings():
+    """Assert nothing warns (``pytest.warns(None)`` is an error in pytest 8+)."""
+    with warnings.catch_warnings(record=True) as log:
+        warnings.simplefilter("always")
+        yield
+    assert not log, f"unexpected warnings: {[str(x.message) for x in log]}"
+
+
+def test_no_warning_when_nothing_excel_only_is_set(tmp_path):
+    path = tmp_path / "plain.csv"
+    with _no_warnings():
+        FastExcel(str(path)).sheet("S", ROWS).save()
+    assert path.read_text().strip() == "a,b\n1.23456,x"
+
+
+def test_autofit_alone_does_not_warn(tmp_path):
+    """autofit defaults to True, so warning on it would fire on every CSV."""
+    with _no_warnings():
+        FastExcel(str(tmp_path / "a.csv"), autofit=True).sheet("S", ROWS).save()
+
+
+def test_sanitize_formulas_does_not_warn(tmp_path):
+    """It is a CSV-only option, not an ignored one."""
+    with _no_warnings():
+        FastExcel(str(tmp_path / "s.csv"), sanitize_formulas=True).sheet(
+            "S", ROWS
+        ).save()
+
+
+def test_warns_and_names_the_ignored_options(tmp_path):
+    path = tmp_path / "fmt.csv"
+    with pytest.warns(UserWarning) as rec:
+        (
+            FastExcel(str(path), password="s3cret")
+            .format(float_format="0.00", bold_headers=True)
+            .freeze(row=1)
+            .sheet("S", ROWS, column_widths={"a": 20}, banded_rows="#EEEEEE")
+            .save()
+        )
+
+    message = str(rec[0].message)
+    for name in (
+        "password",
+        "float_format",
+        "bold_headers",
+        "freeze",
+        "column_widths",
+        "banded_rows",
+    ):
+        assert name in message, f"{name} missing from warning"
+    # The data is still written correctly, unformatted.
+    assert path.read_text().strip() == "a,b\n1.23456,x"
+
+
+@pytest.mark.parametrize(
+    "configure",
+    [
+        pytest.param(lambda f, rows: f.sheet("S", rows, header_row=1), id="header_row"),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, row_heights={0: 20}), id="row_heights"
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, row_formats={0: Format().set_bold()}),
+            id="row_formats",
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, dedupe_strings=True), id="dedupe_strings"
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, header_format=Format().set_bold()),
+            id="header_format",
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, column_formats={"a": Format()}),
+            id="column_formats",
+        ),
+        pytest.param(
+            lambda f, rows: f.sheet("S", rows, column_width=15.0), id="column_width"
+        ),
+        pytest.param(
+            lambda f, rows: f.format(datetime_format="yyyy").sheet("S", rows),
+            id="datetime_format",
+        ),
+        pytest.param(
+            lambda f, rows: f.format(index_columns=["a"]).sheet("S", rows),
+            id="index_columns",
+        ),
+    ],
+)
+def test_each_excel_only_option_warns(tmp_path, configure):
+    """Guards against a new option being added without joining the warning."""
+    f = FastExcel(str(tmp_path / "each.csv"))
+    with pytest.warns(UserWarning, match="ignores Excel-only options"):
+        configure(f, ROWS).save()
+
+
+def test_tsv_warns_too(tmp_path):
+    with pytest.warns(UserWarning, match="ignores Excel-only options"):
+        FastExcel(str(tmp_path / "o.tsv")).format(float_format="0.00").sheet(
+            "S", ROWS
+        ).save()
+
+
+def test_xlsx_never_warns(tmp_path):
+    with _no_warnings():
+        (
+            FastExcel(str(tmp_path / "o.xlsx"), password="s3cret")
+            .format(float_format="0.00")
+            .sheet("S", ROWS, banded_rows="#EEEEEE")
+            .save()
+        )

--- a/tests/test_formula_recalc.py
+++ b/tests/test_formula_recalc.py
@@ -1,0 +1,174 @@
+"""End-to-end formula check: a real spreadsheet engine computes the results.
+
+The unit tests in ``test_formulas.py`` prove the formula *text* survives into
+the file. They cannot prove the file is one a spreadsheet actually understands
+— a wrong ``_xlfn.`` prefix or missing dynamic-array metadata still produces
+plausible-looking XML. Here LibreOffice opens each file headless, recalculates,
+and we assert the computed values.
+
+Skipped automatically when LibreOffice is not installed, so CI without it stays
+green. Run just these with ``pytest -m recalc``.
+"""
+
+import shutil
+import subprocess
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import write_worksheet
+
+SOFFICE = shutil.which("soffice") or shutil.which("libreoffice")
+
+pytestmark = [
+    pytest.mark.recalc,
+    pytest.mark.skipif(SOFFICE is None, reason="LibreOffice not installed"),
+]
+
+
+def _recalculate(path, tmp_path):
+    """Round-trip through LibreOffice and return the recalculated sheet."""
+    outdir = tmp_path / "recalc"
+    outdir.mkdir(exist_ok=True)
+    # A private profile dir keeps this from touching the user's LibreOffice
+    # config and lets concurrent runs coexist.
+    profile = tmp_path / "loprofile"
+    result = subprocess.run(
+        [
+            SOFFICE,
+            "--headless",
+            "--norestore",
+            f"-env:UserInstallation=file://{profile}",
+            "--convert-to",
+            "xlsx",
+            "--outdir",
+            str(outdir),
+            str(path),
+        ],
+        capture_output=True,
+        timeout=240,
+    )
+    converted = outdir / path.name
+    if not converted.exists():
+        raise AssertionError(
+            f"LibreOffice did not produce output: {result.stdout!r} {result.stderr!r}"
+        )
+    return openpyxl.load_workbook(converted, data_only=True).active
+
+
+ROWS = [{"qty": 1, "price": 2.0}, {"qty": 2, "price": 4.0}, {"qty": 3, "price": 6.0}]
+
+
+@pytest.fixture(scope="module")
+def computed(tmp_path_factory):
+    """One conversion for the whole module — LibreOffice startup is slow."""
+    tmp = tmp_path_factory.mktemp("recalc")
+    path = tmp / "formulas.xlsx"
+    write_worksheet(
+        ROWS,
+        str(path),
+        formula_columns={
+            "product": "=A{row}*B{row}",
+            "running": "=SUM(B${first}:B{row})",
+            "branch": '=IF(A{row}>2,"big",IF(A{row}>1,"mid","small"))',
+            "rounded": "=ROUND(B{row}/A{row},2)",
+            "joined": '=A{row}&"x"&B{row}',
+            "lookup": "=INDEX(B:B,MATCH(A{row},A:A,0))",
+            "conditional": '=SUMIFS(B$2:B$4,A$2:A$4,">"&A{row})',
+            "modern_ifs": '=IFS(A{row}>2,"hi",A{row}>1,"mid",TRUE,"lo")',
+            "modern_join": '=TEXTJOIN("-",TRUE,A${first}:A{row})',
+            "modern_max": '=MAXIFS(B$2:B$4,A$2:A$4,"<="&A{row})',
+        },
+        totals_row={
+            "qty": "sum",
+            "price": "=ROUND(AVERAGE({col}{first}:{col}{last}),2)",
+        },
+        totals_label=None,
+    )
+    return _recalculate(path, tmp)
+
+
+@pytest.mark.parametrize(
+    "cell,expected",
+    [
+        # =A2*B2 -> 1*2
+        ("C2", 2),
+        ("C4", 18),
+        # running sum of price
+        ("D2", 2),
+        ("D4", 12),
+        # nested IF
+        ("E2", "small"),
+        ("E3", "mid"),
+        ("E4", "big"),
+        # ROUND(price/qty, 2)
+        ("F2", 2),
+        ("F4", 2),
+        # string concatenation
+        ("G2", "1x2"),
+        # INDEX/MATCH
+        ("H3", 4),
+        # SUMIFS with a comparison built by concatenation
+        ("I2", 10),
+        ("I4", 0),
+        # future functions — these are the ones needing the _xlfn. prefix
+        ("J2", "lo"),
+        ("J4", "hi"),
+        ("K2", "1"),
+        ("K4", "1-2-3"),
+        ("L4", 6),
+    ],
+)
+def test_computed_values(computed, cell, expected):
+    assert computed[cell].value == expected
+
+
+def test_totals_row_computes(computed):
+    """SUM aggregate and a free-form ROUND(AVERAGE(...)) side by side."""
+    assert computed["A5"].value == 6  # 1+2+3
+    assert computed["B5"].value == 4  # (2+4+6)/3
+
+
+def test_dynamic_arrays_are_beyond_this_engine(tmp_path):
+    """Documents the limit of this check, and that the limit is LibreOffice's.
+
+    LibreOffice 24.2 does not implement SORT/UNIQUE/XLOOKUP — they yield
+    ``#NAME?`` even when written by openpyxl with no ``_xlfn.`` prefix at all.
+    So the dynamic-array output is verified structurally in ``test_formulas.py``
+    (``_xlfn.`` prefix, ``t="array"``, ``cm="1"``, ``xl/metadata.xml``) rather
+    than by computing it here. This test fails if a future LibreOffice gains
+    support, which is the signal to promote it to a real value assertion.
+    """
+    path = tmp_path / "dynamic.xlsx"
+    write_worksheet(
+        ROWS,
+        str(path),
+        formula_columns={"sorted": "=SORT(A$2:A$4)", "plain": "=SUM(B$2:B$4)"},
+    )
+    sheet = _recalculate(path, tmp_path)
+
+    assert sheet["C2"].value == "#NAME?", "LibreOffice now supports SORT — tighten this"
+    # An ordinary formula in the same file still computes, so the failure above
+    # is the engine's missing function, not a broken file.
+    assert sheet["D2"].value == 12
+
+
+def test_no_error_values_anywhere(tmp_path):
+    """Guards against a formula landing as #NAME? because of a bad prefix."""
+    path = tmp_path / "clean.xlsx"
+    write_worksheet(
+        ROWS,
+        str(path),
+        formula_columns={
+            "a": "=CONCAT(A${first}:A{row})",
+            "b": '=IFNA(VLOOKUP(A{row},A:B,2,FALSE),"missing")',
+            "c": "=STDEV.P(B$2:B$4)",
+        },
+    )
+    sheet = _recalculate(path, tmp_path)
+    errors = []
+    for row in sheet.iter_rows(min_row=2):
+        for cell in row:
+            if isinstance(cell.value, str) and cell.value.startswith("#"):
+                errors.append((cell.coordinate, cell.value))
+    assert not errors, f"formula errors in output: {errors}"

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -1,0 +1,312 @@
+"""Arbitrary formulas via ``formula_columns`` and free-form ``totals_row``.
+
+Formula text is handed to ``rust_xlsxwriter`` verbatim, which rewrites 161
+"future" and dynamic-array functions with an ``_xlfn.`` prefix and the right
+XML shape. These tests check the text survives that trip intact — see
+``test_formula_recalc.py`` for the values a real spreadsheet engine computes.
+"""
+
+import re
+import zipfile
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, Format, write_worksheet, write_worksheets
+
+
+def _rows(n=3):
+    return [{"qty": i, "price": i * 2.0} for i in range(1, n + 1)]
+
+
+def _sheet(path, name=None):
+    wb = openpyxl.load_workbook(path)
+    return wb[name] if name else wb.active
+
+
+def _formula_xml(path, cell):
+    """The raw <f> text, which is where the _xlfn. rewriting shows up."""
+    xml = zipfile.ZipFile(path).read("xl/worksheets/sheet1.xml").decode()
+    match = re.search(rf'<c r="{cell}"[^>]*>(?:<f[^>]*>(.*?)</f>)?', xml)
+    return match.group(1) if match and match.group(1) else None
+
+
+# --- formula columns ------------------------------------------------------
+
+
+def test_appends_a_computed_column(tmp_path):
+    path = tmp_path / "calc.xlsx"
+    write_worksheet(_rows(3), str(path), formula_columns={"total": "=A{row}*B{row}"})
+
+    ws = _sheet(path)
+    assert [c.value for c in ws[1]] == ["qty", "price", "total"]
+    assert ws["C2"].value == "=A2*B2"
+    assert ws["C3"].value == "=A3*B3"
+    assert ws["C4"].value == "=A4*B4"
+
+
+def test_multiple_columns_keep_their_order(tmp_path):
+    path = tmp_path / "multi.xlsx"
+    write_worksheet(
+        _rows(2),
+        str(path),
+        formula_columns={"total": "=A{row}*B{row}", "half": "=C{row}/2"},
+    )
+    ws = _sheet(path)
+    assert [c.value for c in ws[1]] == ["qty", "price", "total", "half"]
+    assert ws["C2"].value == "=A2*B2"
+    assert ws["D2"].value == "=C2/2"
+
+
+def test_first_placeholder(tmp_path):
+    path = tmp_path / "first.xlsx"
+    write_worksheet(
+        _rows(3), str(path), formula_columns={"cum": "=SUM(B${first}:B{row})"}
+    )
+    ws = _sheet(path)
+    assert ws["C2"].value == "=SUM(B$2:B2)"
+    assert ws["C4"].value == "=SUM(B$2:B4)"
+
+
+def test_last_placeholder_raises_with_a_useful_message(tmp_path):
+    """It cannot be resolved while rows are still streaming."""
+    with pytest.raises(ValueError, match=r"\{last\}.*still streaming"):
+        write_worksheet(
+            _rows(), str(tmp_path / "bad.xlsx"),
+            formula_columns={"share": "=B{row}/SUM(B{first}:B{last})"},
+        )
+
+
+def test_empty_formula_raises(tmp_path):
+    with pytest.raises(ValueError, match="is empty"):
+        write_worksheet(
+            _rows(), str(tmp_path / "bad.xlsx"), formula_columns={"x": "  "}
+        )
+
+
+def test_non_string_formula_raises(tmp_path):
+    with pytest.raises(ValueError, match="must be a formula string"):
+        write_worksheet(
+            _rows(), str(tmp_path / "bad.xlsx"), formula_columns={"x": 42}
+        )
+
+
+def test_formula_columns_shift_with_header_row(tmp_path):
+    path = tmp_path / "offset.xlsx"
+    write_worksheet(
+        _rows(2),
+        str(path),
+        header_row=1,
+        merge_ranges=[(0, 0, 0, 1, "Banner")],
+        formula_columns={"total": "=A{row}*B{row}"},
+    )
+    ws = _sheet(path)
+    assert ws["C2"].value == "total"
+    assert ws["C3"].value == "=A3*B3"
+
+
+def test_autofilter_and_totals_cover_the_computed_column(tmp_path):
+    path = tmp_path / "combo.xlsx"
+    write_worksheet(
+        _rows(3),
+        str(path),
+        formula_columns={"total": "=A{row}*B{row}"},
+        autofilter=True,
+        totals_row={"total": "sum"},
+    )
+    ws = _sheet(path)
+    assert ws.auto_filter.ref == "A1:C4"
+    assert ws["C5"].value == "=SUM(C2:C4)"
+
+
+# --- the formula language itself -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        pytest.param("=IF(A{row}>1,SUM(B$2:B{row}),0)", id="nested-if-sum"),
+        pytest.param('=IF(A{row}>1,IF(A{row}>2,"hi","mid"),"lo")', id="double-if"),
+        pytest.param('=SUMIFS(B:B,A:A,">1")', id="sumifs"),
+        pytest.param("=ROUND(B{row}/A{row},2)", id="round-div"),
+        pytest.param("=SUMPRODUCT((A$2:A$4>1)*(B$2:B$4))", id="sumproduct"),
+        pytest.param("=VLOOKUP(A{row},A:B,2,FALSE)", id="vlookup"),
+        pytest.param('=A{row}&" x "&B{row}', id="concat-operator"),
+        pytest.param("=INDEX(B:B,MATCH(A{row},A:A,0))", id="index-match"),
+    ],
+)
+def test_classic_formulas_pass_through_verbatim(tmp_path, formula):
+    path = tmp_path / "classic.xlsx"
+    write_worksheet(_rows(3), str(path), formula_columns={"f": formula})
+    assert _sheet(path)["C2"].value == formula.replace("{row}", "2")
+
+
+@pytest.mark.parametrize(
+    "formula,expected_prefix",
+    [
+        pytest.param('=TEXTJOIN(",",TRUE,A$2:A$4)', "_xlfn.TEXTJOIN", id="textjoin"),
+        pytest.param('=IFS(A{row}>2,"hi",TRUE,"lo")', "_xlfn.IFS", id="ifs"),
+        pytest.param("=CONCAT(A$2:A$4)", "_xlfn.CONCAT", id="concat"),
+        pytest.param('=MAXIFS(B:B,A:A,">1")', "_xlfn.MAXIFS", id="maxifs"),
+        pytest.param("=STDEV.P(B$2:B$4)", "_xlfn.STDEV.P", id="stdev-p"),
+        pytest.param("=IFNA(A{row},0)", "_xlfn.IFNA", id="ifna"),
+    ],
+)
+def test_future_functions_get_the_xlfn_prefix(tmp_path, formula, expected_prefix):
+    """Excel needs these annotated in the file; the crate does it for us."""
+    path = tmp_path / "future.xlsx"
+    write_worksheet(_rows(3), str(path), formula_columns={"f": formula})
+    assert expected_prefix in _formula_xml(path, "C2")
+
+
+@pytest.mark.parametrize(
+    "formula,expected_prefix",
+    [
+        pytest.param("=XLOOKUP(A{row},A:A,B:B)", "_xlfn.XLOOKUP", id="xlookup"),
+        pytest.param("=UNIQUE(A$2:A$4)", "_xlfn.UNIQUE", id="unique"),
+        pytest.param("=SORT(A$2:A$4)", "_xlfn._xlws.SORT", id="sort-needs-xlws"),
+        pytest.param('=FILTER(A$2:A$4,B$2:B$4>2)', "_xlfn._xlws.FILTER", id="filter"),
+    ],
+)
+def test_dynamic_array_functions(tmp_path, formula, expected_prefix):
+    path = tmp_path / "dynamic.xlsx"
+    write_worksheet(_rows(3), str(path), formula_columns={"f": formula})
+
+    xml = zipfile.ZipFile(path).read("xl/worksheets/sheet1.xml").decode()
+    cell = re.search(r'<c r="C2".*?</c>', xml).group(0)
+    assert expected_prefix in cell
+    # Dynamic arrays need the array shape plus the metadata part.
+    assert 't="array"' in cell
+    assert 'cm="1"' in cell
+    assert "xl/metadata.xml" in zipfile.ZipFile(path).namelist()
+
+
+def test_special_characters_are_xml_escaped(tmp_path):
+    path = tmp_path / "escape.xlsx"
+    write_worksheet(
+        _rows(2),
+        str(path),
+        formula_columns={"f": '=IF(A{row}<2,"a&b",">c")'},
+    )
+    raw = _formula_xml(path, "C2")
+    assert "&lt;" in raw and "&gt;" in raw and "&amp;" in raw
+    # openpyxl unescapes it back to the original text.
+    assert _sheet(path)["C2"].value == '=IF(A2<2,"a&b",">c")'
+
+
+def test_invalid_formula_is_written_unchanged(tmp_path):
+    """Nothing validates formulas — this documents that, deliberately."""
+    path = tmp_path / "invalid.xlsx"
+    write_worksheet(_rows(2), str(path), formula_columns={"f": "=NOTAFUNC(A{row})"})
+    assert _sheet(path)["C2"].value == "=NOTAFUNC(A2)"
+
+
+# --- free-form totals -----------------------------------------------------
+
+
+def test_totals_row_accepts_a_raw_formula(tmp_path):
+    path = tmp_path / "totals.xlsx"
+    write_worksheet(
+        _rows(3),
+        str(path),
+        totals_row={"price": "=MAX({col}{first}:{col}{last})"},
+    )
+    assert _sheet(path)["B5"].value == "=MAX(B2:B4)"
+
+
+def test_totals_formula_and_aggregate_mix(tmp_path):
+    path = tmp_path / "mixed.xlsx"
+    write_worksheet(
+        _rows(3),
+        str(path),
+        totals_row={
+            "qty": "sum",
+            "price": "=ROUND(AVERAGE({col}{first}:{col}{last}),2)",
+        },
+    )
+    ws = _sheet(path)
+    assert ws["A5"].value == "=SUM(A2:A4)"
+    assert ws["B5"].value == "=ROUND(AVERAGE(B2:B4),2)"
+
+
+def test_a_typo_still_raises_rather_than_becoming_a_label(tmp_path):
+    """Only a leading '=' opts into raw-formula mode."""
+    with pytest.raises(ValueError, match="unknown aggregate 'summ'"):
+        write_worksheet(
+            _rows(), str(tmp_path / "bad.xlsx"), totals_row={"qty": "summ"}
+        )
+
+
+# --- all four data paths --------------------------------------------------
+
+
+@pytest.mark.parametrize("frame", ["pandas", "polars"])
+def test_dataframe_paths(tmp_path, frame):
+    mod = pytest.importorskip(frame)
+    df = mod.DataFrame({"qty": [1, 2, 3], "price": [2.0, 4.0, 6.0]})
+    path = tmp_path / f"{frame}.xlsx"
+    write_worksheet(df, str(path), formula_columns={"total": "=A{row}*B{row}"})
+
+    ws = _sheet(path)
+    assert [c.value for c in ws[1]] == ["qty", "price", "total"]
+    assert ws["C2"].value == "=A2*B2"
+    assert ws["C4"].value == "=A4*B4"
+
+
+def test_dataframe_fallback_path(tmp_path):
+    from tests.test_row_layout import _FakeFrame
+
+    df = _FakeFrame({"qty": [1, 2], "price": [2.0, 4.0]}, kinds=["i", "f"])
+    path = tmp_path / "fallback.xlsx"
+    write_worksheet(df, str(path), formula_columns={"total": "=A{row}*B{row}"})
+
+    ws = _sheet(path)
+    assert [c.value for c in ws[1]] == ["qty", "price", "total"]
+    assert ws["C3"].value == "=A3*B3"
+
+
+def test_generator_input(tmp_path):
+    """Streaming input is the reason {last} is unavailable — check it works."""
+    path = tmp_path / "gen.xlsx"
+    write_worksheet(
+        (r for r in _rows(4)), str(path), formula_columns={"total": "=A{row}*B{row}"}
+    )
+    ws = _sheet(path)
+    assert ws["C5"].value == "=A5*B5"
+
+
+def test_multi_sheet_is_per_sheet(tmp_path):
+    path = tmp_path / "multi.xlsx"
+    write_worksheets(
+        [("Calc", _rows(2)), ("Plain", _rows(2))],
+        str(path),
+        formula_columns={"Calc": {"total": "=A{row}*B{row}"}},
+    )
+    wb = openpyxl.load_workbook(path)
+    assert wb["Calc"]["C2"].value == "=A2*B2"
+    assert wb["Plain"]["C2"].value is None
+
+
+def test_fastexcel_builder(tmp_path):
+    path = tmp_path / "builder.xlsx"
+    (
+        FastExcel(str(path))
+        .sheet(
+            "S",
+            _rows(3),
+            formula_columns={"total": "=A{row}*B{row}"},
+            header_format=Format().set_bold(),
+        )
+        .save()
+    )
+    ws = _sheet(path, "S")
+    assert ws["C1"].value == "total"
+    assert ws["C1"].font.bold
+    assert ws["C2"].value == "=A2*B2"
+
+
+def test_csv_warns_that_formula_columns_are_dropped(tmp_path):
+    with pytest.warns(UserWarning, match="formula_columns"):
+        FastExcel(str(tmp_path / "o.csv")).sheet(
+            "S", _rows(2), formula_columns={"total": "=A{row}*B{row}"}
+        ).save()

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -194,8 +194,14 @@ def test_special_characters_are_xml_escaped(tmp_path):
     assert _sheet(path)["C2"].value == '=IF(A2<2,"a&b",">c")'
 
 
-def test_invalid_formula_is_written_unchanged(tmp_path):
-    """Nothing validates formulas — this documents that, deliberately."""
+def test_unknown_function_is_written_unchanged(tmp_path):
+    """Structure is validated; function names deliberately are not.
+
+    LAMBDA and LET bind their own names, workbooks carry user-defined
+    functions, and Excel keeps adding to the list — a name whitelist would
+    reject valid formulas, which is worse than letting a typo through to a
+    ``#NAME?`` in one cell.
+    """
     path = tmp_path / "invalid.xlsx"
     write_worksheet(_rows(2), str(path), formula_columns={"f": "=NOTAFUNC(A{row})"})
     assert _sheet(path)["C2"].value == "=NOTAFUNC(A2)"
@@ -310,3 +316,68 @@ def test_csv_warns_that_formula_columns_are_dropped(tmp_path):
         FastExcel(str(tmp_path / "o.csv")).sheet(
             "S", _rows(2), formula_columns={"total": "=A{row}*B{row}"}
         ).save()
+
+
+# --- structural validation ------------------------------------------------
+# Malformed formulas do not corrupt the file — every case below opens fine in
+# LibreOffice and shows an error value in the cell. Validation only moves the
+# discovery from "when someone opens the report" to "when the export runs", so
+# it is deliberately limited to structure. Rejecting a formula Excel would have
+# accepted is worse than passing a broken one through.
+
+
+@pytest.mark.parametrize(
+    "formula,problem",
+    [
+        pytest.param("=SUM(A2:A5", "unclosed", id="unclosed-paren"),
+        pytest.param("=SUM((A2:A5)", "unclosed", id="one-of-two-unclosed"),
+        pytest.param("=SUM(A2:A5))", "never opened", id="extra-close"),
+        pytest.param('=IF(A2>1,"yes,"no")', "double quote", id="unbalanced-quote"),
+        pytest.param("='Sheet1!A1", "single quote", id="unbalanced-sheet-quote"),
+        pytest.param("=", "empty", id="bare-equals"),
+        pytest.param("=   ", "empty", id="whitespace-only"),
+    ],
+)
+def test_malformed_formulas_are_rejected(tmp_path, formula, problem):
+    with pytest.raises(ValueError, match=problem):
+        write_worksheet(
+            _rows(), str(tmp_path / "bad.xlsx"), formula_columns={"f": formula}
+        )
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        pytest.param('=IF(A2>1,"a)b","c(d")', id="parens-inside-string"),
+        pytest.param("='Sheet (1)'!A1", id="parens-inside-sheet-name"),
+        pytest.param('=A2&""""&B2', id="escaped-quote"),
+        pytest.param('=CONCAT("it\'s",A2)', id="apostrophe-inside-string"),
+        pytest.param("=NOTAFUNC(A2)", id="unknown-function-still-allowed"),
+        pytest.param("SUM(A2:A3)", id="no-leading-equals"),
+        pytest.param("=SUMPRODUCT((A2:A5>1)*(B2:B5))", id="nested-parens"),
+    ],
+)
+def test_valid_formulas_are_not_rejected(tmp_path, formula):
+    """False positives are the failure mode that matters here."""
+    write_worksheet(
+        _rows(), str(tmp_path / "ok.xlsx"), formula_columns={"f": formula}
+    )
+
+
+def test_totals_formula_is_validated_too(tmp_path):
+    with pytest.raises(ValueError, match="totals_row\\['qty'\\].*unclosed"):
+        write_worksheet(
+            _rows(),
+            str(tmp_path / "bad.xlsx"),
+            totals_row={"qty": "=SUM({col}{first}:{col}{last}"},
+        )
+
+
+def test_error_message_names_the_column_and_shows_the_formula(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        write_worksheet(
+            _rows(), str(tmp_path / "bad.xlsx"), formula_columns={"margin": "=A2/("}
+        )
+    message = str(excinfo.value)
+    assert "formula_columns['margin']" in message
+    assert "=A2/(" in message

--- a/tests/test_hyperlinks.py
+++ b/tests/test_hyperlinks.py
@@ -1,0 +1,181 @@
+"""Hyperlinks via ``url_columns``.
+
+``write_url`` rejects anything it cannot classify — plain text, an empty
+string, a URL past 2083 characters — so the writer falls back to plain text
+rather than aborting an export on one bad cell. These tests pin both halves:
+real links become links, everything else survives as readable text.
+"""
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, Format, write_worksheet, write_worksheets
+
+
+def _cell(path, row, col, sheet=None):
+    wb = openpyxl.load_workbook(path)
+    ws = wb[sheet] if sheet else wb.active
+    return ws.cell(row=row, column=col)
+
+
+def test_off_by_default(tmp_path):
+    path = tmp_path / "off.xlsx"
+    write_worksheet([{"link": "https://example.com"}], str(path))
+    c = _cell(path, 2, 1)
+    assert c.value == "https://example.com"
+    assert c.hyperlink is None
+
+
+def test_url_column_becomes_a_link(tmp_path):
+    path = tmp_path / "link.xlsx"
+    write_worksheet(
+        [{"name": "Example", "link": "https://example.com"}],
+        str(path),
+        url_columns=["link"],
+    )
+    c = _cell(path, 2, 2)
+    assert c.hyperlink is not None
+    assert c.hyperlink.target == "https://example.com"
+    assert c.value == "https://example.com"
+    # The non-URL column is untouched.
+    assert _cell(path, 2, 1).hyperlink is None
+
+
+def test_mailto_and_internal_links(tmp_path):
+    path = tmp_path / "kinds.xlsx"
+    write_worksheet(
+        [
+            {"link": "mailto:a@b.com"},
+            {"link": "internal:Sheet1!A1"},
+        ],
+        str(path),
+        sheet_name="Sheet1",
+        url_columns=["link"],
+    )
+    assert _cell(path, 2, 1, "Sheet1").hyperlink.target == "mailto:a@b.com"
+    # Internal links are stored as a location, not a target.
+    internal = _cell(path, 3, 1, "Sheet1").hyperlink
+    assert internal.location == "Sheet1!A1"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("just some text", id="plain-text"),
+        pytest.param("", id="empty"),
+        pytest.param("https://e.com/" + "x" * 2085, id="over-2083-chars"),
+    ],
+)
+def test_non_links_fall_back_to_text(tmp_path, value):
+    """A bad value must not abort the export."""
+    path = tmp_path / "fallback.xlsx"
+    write_worksheet(
+        [{"link": value}, {"link": "https://example.com"}],
+        str(path),
+        url_columns=["link"],
+    )
+    bad = _cell(path, 2, 1)
+    assert bad.hyperlink is None
+    assert (bad.value or "") == value
+    # The following good row still linked.
+    assert _cell(path, 3, 1).hyperlink.target == "https://example.com"
+
+
+def test_none_stays_blank(tmp_path):
+    path = tmp_path / "none.xlsx"
+    write_worksheet(
+        [{"link": None}, {"link": "https://example.com"}],
+        str(path),
+        url_columns=["link"],
+    )
+    assert _cell(path, 2, 1).hyperlink is None
+    assert _cell(path, 3, 1).hyperlink is not None
+
+
+def test_non_string_column_is_ignored(tmp_path):
+    """Numbers in a url column stay numbers."""
+    path = tmp_path / "numeric.xlsx"
+    write_worksheet([{"link": 42}], str(path), url_columns=["link"])
+    c = _cell(path, 2, 1)
+    assert c.value == 42
+    assert c.hyperlink is None
+
+
+def test_unknown_column_warns(tmp_path):
+    with pytest.warns(UserWarning, match="unknown column 'nope'"):
+        write_worksheet(
+            [{"link": "https://example.com"}],
+            str(tmp_path / "warn.xlsx"),
+            url_columns=["nope"],
+        )
+
+
+def test_links_keep_banding_and_column_format(tmp_path):
+    path = tmp_path / "styled.xlsx"
+    write_worksheet(
+        [{"link": f"https://example.com/{i}"} for i in range(4)],
+        str(path),
+        url_columns=["link"],
+        banded_rows="#F2F2F2",
+    )
+    banded = _cell(path, 3, 1)
+    assert banded.hyperlink is not None
+    assert banded.fill.fgColor.rgb == "FFF2F2F2"
+
+
+@pytest.mark.parametrize("frame", ["pandas", "polars"])
+def test_dataframe_paths(tmp_path, frame):
+    mod = pytest.importorskip(frame)
+    df = mod.DataFrame(
+        {"name": ["a", "b"], "link": ["https://example.com", "not a link"]}
+    )
+    path = tmp_path / f"{frame}.xlsx"
+    write_worksheet(df, str(path), url_columns=["link"])
+
+    assert _cell(path, 2, 2).hyperlink.target == "https://example.com"
+    assert _cell(path, 3, 2).hyperlink is None
+    assert _cell(path, 3, 2).value == "not a link"
+
+
+def test_dataframe_fallback_path(tmp_path):
+    from tests.test_row_layout import _FakeFrame
+
+    df = _FakeFrame({"link": ["https://example.com", "nope"]}, kinds=["O"])
+    path = tmp_path / "fallback-df.xlsx"
+    write_worksheet(df, str(path), url_columns=["link"])
+    assert _cell(path, 2, 1).hyperlink.target == "https://example.com"
+    assert _cell(path, 3, 1).hyperlink is None
+
+
+def test_multi_sheet_is_per_sheet(tmp_path):
+    path = tmp_path / "multi.xlsx"
+    rows = [{"link": "https://example.com"}]
+    write_worksheets(
+        [("Linked", rows), ("Plain", rows)],
+        str(path),
+        url_columns={"Linked": ["link"]},
+    )
+    assert _cell(path, 2, 1, "Linked").hyperlink is not None
+    assert _cell(path, 2, 1, "Plain").hyperlink is None
+
+
+def test_fastexcel_builder(tmp_path):
+    path = tmp_path / "builder.xlsx"
+    (
+        FastExcel(str(path))
+        .sheet(
+            "S",
+            [{"link": "https://example.com"}],
+            url_columns=["link"],
+            header_format=Format().set_bold(),
+        )
+        .save()
+    )
+    assert _cell(path, 2, 1, "S").hyperlink is not None
+
+
+def test_csv_warns_that_url_columns_are_dropped(tmp_path):
+    with pytest.warns(UserWarning, match="url_columns"):
+        FastExcel(str(tmp_path / "o.csv")).sheet(
+            "S", [{"link": "https://example.com"}], url_columns=["link"]
+        ).save()

--- a/tests/test_totals_row.py
+++ b/tests/test_totals_row.py
@@ -144,12 +144,31 @@ def test_autofilter_range_excludes_the_totals_row(tmp_path):
     assert ws["B6"].value == "=SUM(B2:B5)"
 
 
-def test_cached_result_is_zero_until_excel_recalculates(tmp_path):
-    """Documented caveat, pinned so it cannot change silently."""
+def test_uncomputed_result_reads_as_none_not_zero(tmp_path):
+    """The cached result must be empty, never a plausible-looking wrong total.
+
+    rust_xlsxwriter defaults the cached result to 0, so a reader trusting the
+    cache would see ``0`` as the sum. An empty result reads back as "not
+    computed" — and per the crate's docs it is also what makes LibreOffice
+    recalculate instead of showing the stale value.
+    """
     path = tmp_path / "cached.xlsx"
     write_worksheet(_records(3), str(path), totals_row={"amount": "sum"})
+
     cached = openpyxl.load_workbook(path, data_only=True).active
-    assert cached["B5"].value == 0
+    assert cached["B5"].value is None
+    # The formula itself is intact.
+    assert openpyxl.load_workbook(path).active["B5"].value == "=SUM(B2:B4)"
+
+
+def test_data_cells_keep_their_values(tmp_path):
+    """set_formula_result_default must not touch ordinary cells."""
+    path = tmp_path / "data.xlsx"
+    write_worksheet(_records(3), str(path), totals_row={"amount": "sum"})
+    cached = openpyxl.load_workbook(path, data_only=True).active
+    assert cached["B2"].value == 0.0
+    assert cached["B3"].value == 1.5
+    assert cached["A2"].value == "n0"
 
 
 @pytest.mark.parametrize("frame", ["pandas", "polars"])

--- a/tests/test_totals_row.py
+++ b/tests/test_totals_row.py
@@ -1,0 +1,216 @@
+"""Totals row — aggregate formulas written below the data.
+
+Like autofilter this lands after the data: the row sits underneath it and the
+formula ranges depend on how many rows there turned out to be.
+"""
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, Format, write_worksheet, write_worksheets
+
+
+def _records(n=4):
+    return [{"name": f"n{i}", "amount": i * 1.5, "qty": i} for i in range(n)]
+
+
+def _sheet(path, name=None):
+    wb = openpyxl.load_workbook(path)
+    return wb[name] if name else wb.active
+
+
+def test_off_by_default(tmp_path):
+    path = tmp_path / "off.xlsx"
+    write_worksheet(_records(), str(path))
+    assert _sheet(path)["A6"].value is None
+
+
+def test_sum_formula_covers_the_data_range(tmp_path):
+    path = tmp_path / "sum.xlsx"
+    write_worksheet(_records(4), str(path), totals_row={"amount": "sum"})
+    ws = _sheet(path)
+    # Header row 1, data rows 2-5, totals on row 6.
+    assert ws["B6"].value == "=SUM(B2:B5)"
+    assert ws["A6"].value is None
+
+
+def test_label_and_format(tmp_path):
+    path = tmp_path / "labelled.xlsx"
+    write_worksheet(
+        _records(3),
+        str(path),
+        totals_row={"amount": "sum", "qty": "sum"},
+        totals_label="Total",
+        totals_format=Format().set_bold().set_border_top("thin"),
+    )
+    ws = _sheet(path)
+    assert ws["A5"].value == "Total"
+    assert ws["B5"].value == "=SUM(B2:B4)"
+    assert ws["C5"].value == "=SUM(C2:C4)"
+    for ref in ("A5", "B5", "C5"):
+        assert ws[ref].font.bold
+        assert ws[ref].border.top.style == "thin"
+
+
+@pytest.mark.parametrize(
+    "aggregate,expected",
+    [
+        ("sum", "SUM"),
+        ("average", "AVERAGE"),
+        ("avg", "AVERAGE"),
+        ("mean", "AVERAGE"),
+        ("count", "COUNT"),
+        ("min", "MIN"),
+        ("max", "MAX"),
+        ("product", "PRODUCT"),
+        ("stdev", "STDEV"),
+        ("SUM", "SUM"),
+    ],
+)
+def test_supported_aggregates(tmp_path, aggregate, expected):
+    path = tmp_path / f"{aggregate}.xlsx"
+    write_worksheet(_records(3), str(path), totals_row={"amount": aggregate})
+    assert _sheet(path)["B5"].value == f"={expected}(B2:B4)"
+
+
+def test_unknown_aggregate_raises(tmp_path):
+    with pytest.raises(ValueError, match="unknown aggregate 'summ'"):
+        write_worksheet(
+            _records(), str(tmp_path / "bad.xlsx"), totals_row={"amount": "summ"}
+        )
+
+
+def test_unknown_column_warns_and_skips(tmp_path):
+    path = tmp_path / "warn.xlsx"
+    with pytest.warns(UserWarning, match="unknown column 'nope'"):
+        write_worksheet(
+            _records(3),
+            str(path),
+            totals_row={"nope": "sum", "amount": "sum"},
+        )
+    # The valid column is still totalled.
+    assert _sheet(path)["B5"].value == "=SUM(B2:B4)"
+
+
+def test_label_colliding_with_a_formula_raises(tmp_path):
+    with pytest.raises(ValueError, match="totals_label would overwrite"):
+        write_worksheet(
+            _records(),
+            str(tmp_path / "clash.xlsx"),
+            totals_row={"name": "count"},
+            totals_label="Total",
+        )
+
+
+def test_no_data_means_no_totals_row(tmp_path):
+    """A formula over an empty range would be invalid."""
+    path = tmp_path / "empty.xlsx"
+    write_worksheet([], str(path), totals_row={"amount": "sum"}, totals_label="Total")
+    ws = _sheet(path)
+    assert ws["A1"].value is None
+    assert ws["A2"].value is None
+
+
+def test_single_row(tmp_path):
+    path = tmp_path / "one.xlsx"
+    write_worksheet(_records(1), str(path), totals_row={"amount": "sum"})
+    assert _sheet(path)["B3"].value == "=SUM(B2:B2)"
+
+
+def test_range_follows_header_row(tmp_path):
+    path = tmp_path / "offset.xlsx"
+    write_worksheet(
+        _records(3),
+        str(path),
+        header_row=2,
+        merge_ranges=[(0, 0, 0, 2, "Banner")],
+        totals_row={"amount": "sum"},
+    )
+    # Header on row 3, data rows 4-6, totals on row 7.
+    assert _sheet(path)["B7"].value == "=SUM(B4:B6)"
+
+
+def test_autofilter_range_excludes_the_totals_row(tmp_path):
+    """Otherwise sorting or filtering would drag the total into the data."""
+    path = tmp_path / "filtered.xlsx"
+    write_worksheet(
+        _records(4),
+        str(path),
+        autofilter=True,
+        totals_row={"amount": "sum"},
+    )
+    ws = _sheet(path)
+    assert ws.auto_filter.ref == "A1:C5"
+    assert ws["B6"].value == "=SUM(B2:B5)"
+
+
+def test_cached_result_is_zero_until_excel_recalculates(tmp_path):
+    """Documented caveat, pinned so it cannot change silently."""
+    path = tmp_path / "cached.xlsx"
+    write_worksheet(_records(3), str(path), totals_row={"amount": "sum"})
+    cached = openpyxl.load_workbook(path, data_only=True).active
+    assert cached["B5"].value == 0
+
+
+@pytest.mark.parametrize("frame", ["pandas", "polars"])
+def test_dataframe_paths(tmp_path, frame):
+    mod = pytest.importorskip(frame)
+    df = mod.DataFrame({"name": ["a", "b", "c"], "amount": [1.0, 2.0, 3.0]})
+    path = tmp_path / f"{frame}.xlsx"
+    write_worksheet(df, str(path), totals_row={"amount": "sum"})
+    assert _sheet(path)["B5"].value == "=SUM(B2:B4)"
+
+
+def test_dataframe_fallback_path(tmp_path):
+    from tests.test_row_layout import _FakeFrame
+
+    df = _FakeFrame({"amount": [1.0, 2.0]}, kinds=["f"])
+    path = tmp_path / "fallback.xlsx"
+    write_worksheet(df, str(path), totals_row={"amount": "sum"})
+    assert _sheet(path)["A4"].value == "=SUM(A2:A3)"
+
+
+def test_column_letter_past_z(tmp_path):
+    """Column 27 is AB — the letter conversion must not be a single char."""
+    row = {f"c{i}": i for i in range(28)}
+    path = tmp_path / "wide.xlsx"
+    write_worksheet([row, row], str(path), totals_row={"c27": "sum"})
+    assert _sheet(path)["AB4"].value == "=SUM(AB2:AB3)"
+
+
+def test_multi_sheet_is_per_sheet(tmp_path):
+    path = tmp_path / "multi.xlsx"
+    write_worksheets(
+        [("Totalled", _records(3)), ("Plain", _records(3))],
+        str(path),
+        totals_row={"Totalled": {"amount": "sum"}},
+        totals_label={"Totalled": "Total"},
+    )
+    assert _sheet(path, "Totalled")["B5"].value == "=SUM(B2:B4)"
+    assert _sheet(path, "Totalled")["A5"].value == "Total"
+    assert _sheet(path, "Plain")["A5"].value is None
+
+
+def test_fastexcel_builder(tmp_path):
+    path = tmp_path / "builder.xlsx"
+    (
+        FastExcel(str(path))
+        .sheet(
+            "S",
+            _records(5),
+            totals_row={"amount": "average"},
+            totals_label="Mean",
+            totals_format=Format().set_bold(),
+        )
+        .save()
+    )
+    ws = _sheet(path, "S")
+    assert ws["A7"].value == "Mean"
+    assert ws["B7"].value == "=AVERAGE(B2:B6)"
+
+
+def test_csv_warns_that_totals_are_dropped(tmp_path):
+    with pytest.warns(UserWarning, match="totals_row"):
+        FastExcel(str(tmp_path / "o.csv")).sheet(
+            "S", _records(3), totals_row={"amount": "sum"}
+        ).save()


### PR DESCRIPTION
Six changes: two fixes found while auditing the wrapper, plus autofilter, hyperlinks, a totals row, and arbitrary formula support.

## 1. CSV silently discarded every Excel option

Writing to `.csv`/`.tsv` dropped `float_format`, `datetime_format`, `index_columns`, `bold_headers`, `password`, freeze panes, column widths and formats, `header_format`, `dedupe_strings`, `header_row`, `merge_ranges`, `row_heights`, `row_formats`, `banded_rows` and `autofilter` — with no signal whatsoever. Confirmed before the fix:

```python
FastExcel("o.csv", password="x").format(float_format="0.00") \
    .sheet("S", [{"a": 1.23456}], banded_rows="#EEE").save()
# warnings: NONE
# o.csv: a
#        1.23456      <- float_format ignored too
```

The README made it worse by advertising the CSV path as *"same API, no code change"*. Someone switching a target from `.xlsx` to `.csv` lost all formatting with no way to notice.

The builder now names what it threw away:

```
UserWarning: CSV/TSV output ignores Excel-only options: password, float_format,
banded_rows. The file will contain unformatted values; write to '.xlsx' if you
need them.
```

`autofit` and `sanitize_formulas` are deliberately excluded — the first defaults to `True` so it would fire on every CSV write, the second is CSV-only. The data itself is unchanged; only the warning is new. The test is parametrised over each option individually, so a future option that forgets to join the warning fails there rather than going quiet.

## 2. Dev requirements could not be installed

`requirements.txt` line 32 pinned the package to itself:

```
-e git+ssh://git@github.com/rahmadafandi/rustpy-xlsxwriter.git@c42b28d…#egg=rustpy_xlsxwriter
```

`c42b28d` is v0.4.2 — two minor versions stale. Anyone without SSH access to the repo could not run `pip install -r requirements.txt` at all, and anyone with access silently got an old build to test against. Replaced with `-e .`.

Verified in a clean venv from the repo root:

```
pip install -r requirements.txt   → builds the extension, ~50s
get_version()                     → 0.6.0   (was 0.4.2)
pytest -m "not benchmark"         → 201 passed
```

Note `-e .` resolves against the working directory, which is standard pip behaviour for requirements files — run it from the repo root, as the docs already assume.

## 3. Autofilter

Filter dropdowns over the header row and its data — the most-used Excel feature this library did not expose.

```python
FastExcel("report.xlsx").sheet("Data", rows, autofilter=True, freeze_row=1).save()
```

`write_worksheets` takes a dict keyed by sheet name with the usual `"general"` fallback.

**Why it is applied after the data.** Every other layout option lands before the first cell, because constant-memory mode cannot revisit a flushed row. Autofilter is the exception: its range needs the final row count, known only once the last row is written. That turns out to be fine — the `autoFilter` element lives in the worksheet footer, not in the row data. Verified against a real file before writing any of this:

```
Sheet1 -> A1:B6     # filter added after all rows flushed
Offset -> A2:B5     # header pushed down by a merged banner
Empty  -> A1        # header only
```

So each of the four data paths now reports how many rows it wrote, and the range is derived from that. The caller never supplies bounds, and the range follows `header_row` automatically.

| Input | Range |
|---|---|
| 5 rows, 3 columns | `A1:C6` |
| `header_row=2` with a banner above | `A3:C7` |
| single row | `A1:C2` |
| empty records (no headers written) | no filter |

Also covered: all four data paths (Arrow, Records, Pandas, Polars — the last via the `_FakeFrame` stub, since pandas 3 and polars both take the Arrow path), per-sheet and `"general"` keys, and composition with freeze panes and banding.

## 4. Hyperlinks (issue #20, item 6)

Name the columns that hold links:

```python
FastExcel("report.xlsx").sheet("Docs", rows, url_columns=["homepage"]).save()
```

Named columns rather than auto-detecting `http://` in strings — auto-detection would silently change output for anyone already exporting URLs as text. `url_columns` follows `index_columns`, which is also a list of column names.

**The fallback matters.** `write_url` rejects anything it cannot classify, which a probe confirmed before any code was written:

```
OK       https://example.com
OK       mailto:a@b.com
OK       internal:Sheet1!A1
CALL-ERR just some text          Unknown/unsupported url type
CALL-ERR ''                      Unknown/unsupported url type
CALL-ERR <2100 chars>            exceeds Excel's limit of 2083 characters
```

Calling it blindly over a column would abort an export on the first blank cell. So a value Excel would reject is written as plain text instead — visible and correct, just not clickable. Tests pin all three rejection cases and that a following good row still links.

Links keep their banding and column format. Unknown column names warn and are skipped, matching `column_formats`.

## 5. Totals row (issue #20 follow-on)

Aggregate formulas below the data, with ranges derived from the rows actually written:

```python
FastExcel("report.xlsx").sheet(
    "Sales", rows,
    totals_row={"amount": "sum", "qty": "sum"},
    totals_label="Total",
    totals_format=Format().set_bold().set_border_top("thin"),
).save()
# amount column gets  =SUM(C2:C101)
```

Aggregates: `sum`, `average` (`avg`/`mean`), `count`, `min`, `max`, `product`, `stdev`. An unknown one raises rather than writing a broken formula; an unknown column name warns and is skipped.

`totals_format` is its own argument because the totals row index depends on how much data there was, so `row_formats` cannot reach it. This also completes the "top border above the totals row" part of issue #20 item 4 — the border was already possible, but there was no totals row to put it on.

**Edge cases that would otherwise produce broken files:**
- No data rows → the row is skipped entirely, since `=SUM(B2:B1)` is not a valid range.
- `totals_label` colliding with an aggregate in the first column → raises, instead of one silently overwriting the other.
- `autofilter` stops above the totals row, so sorting never drags the total into the data.
- Columns past Z use the proper letter (`AB`, not a truncated single char).

> **Caveat, documented and pinned by a test:** the formulas carry no computed result. Readers that use cached values — `pandas.read_excel`, `openpyxl` with `data_only=True` — see `0` until Excel or LibreOffice opens the file and recalculates. Suited to files people open, not to a machine-readable handoff.

## 6. Arbitrary formulas

`rust_xlsxwriter` passes formula text straight through to the file, so exposing a way to write one opens the entire Excel formula language at once — there is no function list to maintain here.

```python
FastExcel("report.xlsx").sheet(
    "Sales", rows,
    formula_columns={
        "total":   "=A{row}*B{row}",
        "running": "=SUM(B${first}:B{row})",
    },
    totals_row={"qty": "sum", "price": "=ROUND(AVERAGE({col}{first}:{col}{last}),2)"},
).save()
```

`formula_columns` appends computed columns after the data, one formula per row. `totals_row` values starting with `=` are used as raw formulas. Nested calls, `SUMIFS`, `INDEX`/`MATCH` and cross-sheet references all work, and so do the 131 "future" functions the crate rewrites with an `_xlfn.` prefix and the 30 dynamic-array ones that also need array markup plus `xl/metadata.xml`.

**No `{last}` in `formula_columns`.** Those cells are written while rows are still streaming, so the final row is unknown. Using it raises and points at `totals_row`, rather than silently producing a wrong range.

### Validation, scoped by measurement

Malformed formulas were checked against LibreOffice before deciding what to validate. **None of them corrupt the file** — every case opened fine:

| Formula | Result |
|---|---|
| `=SUM(A2:A5` (unclosed) | **3** — LibreOffice closes it |
| `=SUM(A2:A5))` | `#VALUE!` |
| `=NOTAFUNC(A2)` | `#NAME?` |
| `=A2+` | `#N/A` |

So validation only moves discovery from "when someone opens the report" to "when the export runs", which makes a false positive strictly worse than a false negative. It is therefore limited to structure — balanced parentheses and quotes, non-empty — and deliberately does **not** check function names: `LAMBDA`/`LET` bind their own, workbooks carry user-defined functions, and Excel keeps adding to the list.

The scanner tracks double-quoted strings (with doubled-quote escapes) and single-quoted sheet names, so parentheses inside either count as text. These all pass: `=IF(A2>1,"a)b","c(d")` and `='Sheet (1)'!A1`.

### Formulas are verified by a real engine

`tests/test_formula_recalc.py` opens each file in headless LibreOffice, recalculates, and asserts the computed values. It auto-skips when LibreOffice is absent, so CI stays green (297 pass without it, 334 with).

**This caught a bug the unit tests could not.** Without an empty cached result, LibreOffice trusted the crate's default of `0` and never recalculated — so every computed column read as zero while the formula text was perfectly correct. `set_formula_result_default("")` now applies to every formula the sheet writes, not just totals.

One documented limit: LibreOffice 24.2 does not implement `SORT`/`UNIQUE`/`XLOOKUP` at all — they yield `#NAME?` even when written by openpyxl with no prefix. Dynamic arrays are therefore verified structurally, and the test fails if a future LibreOffice gains support, which is the signal to tighten it.

## Verification

```
cargo build --release            → OK
cargo clippy --release           → 14 warnings, same as master (none new)
pytest tests/ -m "not benchmark" → 334 passed (148 new); 297 without LibreOffice
clean-venv install               → 0.6.0, all tests pass
```

No performance regression. The only per-row addition is a `u32` store for the row counter; at 200k rows the difference sits inside run-to-run drift on this machine (it measured 3–4% *faster*, which is machine state, not a real speedup — absolute times moved ~16% between runs in the same session).

No version bump: 0.6.0 is not released yet, so this rides on it.




