### PR TITLE
fix: two silent-empty-output bugs; add cp314t wheels and concurrency benchmark

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,6 +143,51 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
 
+  freethreaded:
+    # The jobs above use --find-interpreter, which only sees the interpreters
+    # installed on the runner. A free-threaded build is a separate binary
+    # (python3.14t), so it is never picked up and no cp314t wheel is produced —
+    # even though the package advertises Python 3.14 support.
+    #
+    # Scoped to the platforms free-threading is actually run on. The exotic
+    # linux targets (s390x, ppc64le, armv7, x86) have no free-threaded
+    # interpreter available, and cross-building one is not worth it until
+    # somebody asks.
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      # One platform lacking a 3.14t interpreter must not hide the others.
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: ubuntu-22.04
+            target: x86_64
+          - runner: ubuntu-22.04
+            target: aarch64
+          - runner: macos-latest
+            target: aarch64
+          - runner: macos-15-intel
+            target: x86_64
+          - runner: windows-latest
+            target: x64
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: 3.14t
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          # Name the interpreter explicitly — discovery is what misses it.
+          args: --release --out dist -i python3.14t
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-freethreaded-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          path: dist
+
   sdist:
     runs-on: ubuntu-latest
     steps:
@@ -162,7 +207,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux, windows, macos, sdist]
+    needs: [linux, musllinux, windows, macos, freethreaded, sdist]
     permissions:
       # Use to sign the release artifacts
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "rustpy-xlsxwriter"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpy-xlsxwriter"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Rahmad Afandi <rahmadafandiii@gmail.com>"]
 description = "High-performance Excel and CSV file generation powered by Rust (~7-9x faster)"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Docs](https://img.shields.io/badge/docs-API%20reference-blue)](https://rahmadafandi.github.io/rustpy-xlsxwriter/)
 [![Donate](https://img.shields.io/badge/donate-Saweria-orange)](https://saweria.co/rahmadafandi)
 
-High-performance Excel and CSV file generation for Python, powered by Rust. **~7x-9x faster** than [XlsxWriter](https://github.com/jmcnamara/XlsxWriter), **~5x faster** CSV (records) than Python's `csv` module, and **~12x faster** Pandas DataFrame → CSV than `pandas.to_csv` via zero-copy Arrow.
+High-performance Excel and CSV file generation for Python, powered by Rust. **~7x-9x faster** than [XlsxWriter](https://github.com/jmcnamara/XlsxWriter), **~5x faster** CSV (records) than Python's `csv` module, and **~12x faster** Pandas DataFrame → CSV than `pandas.to_csv` via zero-copy Arrow. On free-threaded Python the gap widens to **~9.4x**, because it parallelises better than a pure-Python writer can — see [Concurrency](#concurrency).
 
 ```python
 from rustpy_xlsxwriter import FastExcel
@@ -21,6 +21,30 @@ FastExcel("report.xlsx").sheet("Sheet1", records).save()
 ```bash
 pip install rustpy-xlsxwriter
 ```
+
+Prebuilt wheels cover CPython on Linux (glibc and musl), macOS and Windows.
+
+### Free-threaded Python
+
+Python 3.14 makes the free-threaded build officially supported. It is a
+*separate* interpreter — `python3.14t` — not the default one, so you have to
+install it deliberately:
+
+```bash
+uv python install 3.14t          # or your distro's python3.14-freethreading package
+uv venv --python 3.14t
+uv pip install rustpy-xlsxwriter # installs the cp314t wheel
+```
+
+Check which one you are on:
+
+```python
+import sys
+sys.version                # "... free-threading build ..." on 3.14t
+sys._is_gil_enabled()      # False on a free-threaded build
+```
+
+Nothing in the API changes. See [Concurrency](#concurrency) for what it buys.
 
 ## Performance
 
@@ -41,7 +65,57 @@ Benchmarked via [`benchmark.py`](benchmark.py) — run `python benchmark.py` to 
 
 *Baselines: Excel → Python `xlsxwriter`; Records CSV → Python `csv` module; Pandas DataFrame CSV → `DataFrame.to_csv()`.*
 
+**Every row above is single-threaded, and the GIL keeps it that way.** On
+free-threaded Python both writers spread across threads — but RustPy spreads
+further, so the speedup against `xlsxwriter` grows from **7.4x to 9.4x** at
+eight threads. Full numbers in [Concurrency](#concurrency).
+
 † *DataFrame → CSV rows measured on a separate machine — only speedup ratio shown. The Pandas path goes through zero-copy Arrow C Data Interface.*
+
+### Concurrency
+
+Every row below writes **the same 1,000,000 records** — the Records row from the
+table above — just spread over more workers. `xlsxwriter` is measured at each
+worker count too. Reproduce with `python benchmark.py --concurrent` under each
+interpreter:
+
+**Python 3.14 — standard build**
+
+| Workers | RustPy | xlsxwriter | Speedup |
+|---|---|---|---|
+| 1 | 5.40s | 43.47s | 8.0x |
+| 2 | 5.72s | 40.72s | 7.1x |
+| 4 | 5.70s | 39.79s | 7.0x |
+| 8 | 5.69s | 39.55s | 6.9x |
+
+**Python 3.14t — free-threaded**
+
+| Workers | RustPy | xlsxwriter | Speedup |
+|---|---|---|---|
+| 1 | 6.10s | 45.00s | 7.4x |
+| 2 | 3.20s | 27.17s | 8.5x |
+| 4 | 2.09s | 18.83s | 9.0x |
+| 8 | **1.72s** | 16.21s | **9.4x** |
+
+With the GIL both columns are flat: threads take turns, so the 1M records cost
+the same whether one worker writes them or eight.
+
+Without it both writers spread out — `xlsxwriter` is pure Python and gets faster
+too, from 45.00s to 16.21s (**2.8x**). RustPy goes from 6.10s to 1.72s
+(**3.5x**), because more of its work is Rust rather than interpreted bytecode.
+That is why the advantage widens rather than staying put: 7.4x at one worker,
+9.4x at eight.
+
+The cost is a single write being ~10% slower on 3.14t, the usual price of the
+free-threaded interpreter. So: one big export favours the standard build, many
+concurrent exports favour the free-threaded one.
+
+Measured on 10 physical cores, on a different machine than the table above — read
+each row's columns against each other, not against the rows above.
+
+Two caveats: Polars has no free-threaded wheel yet, so that input path is
+unavailable on 3.14t (Pandas, Arrow and records all work). And the free-threaded
+build is younger — treat it as the newer option it is.
 
 <details>
 <summary>Key optimizations</summary>
@@ -78,6 +152,10 @@ Benchmarked via [`benchmark.py`](benchmark.py) — run `python benchmark.py` to 
 - Password protection (Excel only)
 - Optional column auto-fit (`autofit=True/False`)
 - Multiple sheets in a single file (Excel only)
+
+**Runtime**
+- CPython 3.8+ — prebuilt wheels for Linux (glibc/musl), macOS, Windows
+- Free-threaded builds (`python3.14t`) — parallel writes, see [Concurrency](#concurrency)
 
 **API**
 - Fluent builder via `FastExcel` class

--- a/benchmark.py
+++ b/benchmark.py
@@ -8,7 +8,13 @@ Compares rustpy-xlsxwriter vs Python xlsxwriter for:
 - Polars DataFrame: 500K and 1M rows
 
 Usage:
-    python benchmark.py
+    python benchmark.py              # the comparison above
+    python benchmark.py --concurrent # 1M rows split across 1/2/4/8 threads
+
+The concurrency run is the interesting one on a free-threaded build
+(``python3.14t``): with the GIL the total time is flat no matter how many
+threads, without it the work actually spreads. Run it under both interpreters
+to see the difference.
 """
 
 import os
@@ -18,9 +24,19 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List
 
 import numpy as np
-import pandas as pd
-import polars as pl
 import xlsxwriter
+
+# Optional: the DataFrame comparisons need these, the records and concurrency
+# runs do not. Polars has no free-threaded wheel yet, so importing it eagerly
+# would stop `--concurrent` from running on the interpreter it exists for.
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover
+    pd = None
+try:
+    import polars as pl
+except ImportError:  # pragma: no cover
+    pl = None
 
 from rustpy_xlsxwriter import FastExcel, write_csv
 
@@ -139,8 +155,71 @@ def cleanup(path: str) -> None:
         os.remove(path)
 
 
+def bench_concurrent() -> None:
+    """Write the same 1M rows split across N threads, for N in 1/2/4/8.
+
+    Both writers are measured at every worker count. xlsxwriter is pure Python,
+    so on a free-threaded build it spreads across threads too — comparing a
+    parallel rustpy run against a single-threaded baseline would flatter us.
+    The speedup column therefore pits the two against each other at the same
+    worker count, which is what the table in the README reports.
+    """
+    import sys
+    from concurrent.futures import ThreadPoolExecutor
+
+    total = 1_000_000
+    gil = getattr(sys, "_is_gil_enabled", lambda: True)()
+    print(f"Python {sys.version.split()[0]} — GIL {'enabled' if gil else 'DISABLED'}")
+    print(f"Generating {total:,} records...")
+    records = generate_records(total)
+    headers = list(records[0].keys())
+
+    print()
+    print("=" * 62)
+    print(f"Every row writes the same {total:,} records, spread over the workers.")
+    print(f"{'Workers':>8} {'RustPy':>10} {'xlsxwriter':>13} {'Speedup':>10}")
+    print("-" * 62)
+
+    for workers in (1, 2, 4, 8):
+        per = total // workers
+        chunks = [records[w * per : (w + 1) * per] for w in range(workers)]
+
+        def spread(job) -> None:
+            if workers == 1:
+                job(0)
+            else:
+                with ThreadPoolExecutor(workers) as pool:
+                    list(pool.map(job, range(workers)))
+
+        def rust(w: int) -> None:
+            path = os.path.join(TMP_DIR, f"conc_r{w}.xlsx")
+            FastExcel(path, autofit=False).sheet("B", chunks[w]).save()
+
+        def xlsx(w: int) -> None:
+            path = os.path.join(TMP_DIR, f"conc_x{w}.xlsx")
+            rows = (list(r.values()) for r in chunks[w])
+            _xlsxwriter_write(path, headers, rows)
+
+        spread(rust)  # warm caches so the first row is not penalised
+        t_r = min(bench("", spread, rust) for _ in range(3))
+        t_x = bench("", spread, xlsx)  # one pass: this one is slow
+
+        print(f"{workers:>8} {t_r:>9.2f}s {t_x:>12.2f}s {t_x / t_r:>9.1f}x")
+        for w in range(workers):
+            cleanup(os.path.join(TMP_DIR, f"conc_r{w}.xlsx"))
+            cleanup(os.path.join(TMP_DIR, f"conc_x{w}.xlsx"))
+    print("=" * 62)
+    if gil:
+        print("Flat: the GIL serialises both writers.")
+    else:
+        print("Free-threaded: both spread across threads — the ratio is the honest gain.")
+
+
 def main() -> None:
     os.makedirs(TMP_DIR, exist_ok=True)
+    for name, mod in (("pandas", pd), ("polars", pl)):
+        if mod is None:
+            print(f"({name} not installed — skipping its section)")
 
     results = []
 
@@ -166,7 +245,7 @@ def main() -> None:
         cleanup(p2)
 
     # --- Pandas DataFrame ---
-    for n in [500_000, 1_000_000]:
+    for n in [] if pd is None else [500_000, 1_000_000]:
         label = f"{n:,}"
         print(f"Generating Pandas DataFrame ({label} rows)...")
         df = generate_pandas_df(n)
@@ -187,7 +266,7 @@ def main() -> None:
         cleanup(p2)
 
     # --- Polars DataFrame ---
-    for n in [500_000, 1_000_000]:
+    for n in [] if pl is None else [500_000, 1_000_000]:
         label = f"{n:,}"
         print(f"Generating Polars DataFrame ({label} rows)...")
         df_pl = generate_polars_df(n)
@@ -257,4 +336,11 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+
+    if "--concurrent" in sys.argv:
+        os.makedirs(TMP_DIR, exist_ok=True)
+        bench_concurrent()
+        os.rmdir(TMP_DIR)
+    else:
+        main()

--- a/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
+++ b/rustpy_xlsxwriter/rustpy_xlsxwriter.pyi
@@ -452,7 +452,7 @@ def validate_sheet_name(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def get_version() -> str:
-    """Return the package version string (e.g. ``'0.6.0'``)."""
+    """Return the package version string (e.g. ``'0.6.1'``)."""
     ...
 
 def get_name() -> str:

--- a/src/csv_writer.rs
+++ b/src/csv_writer.rs
@@ -9,6 +9,14 @@ use pyo3::Py;
 use crate::cell::{classify_and_write, try_cached, CellWriter};
 use crate::helpers::{write_bytes_to_target, write_csv_escaped_guarded, ColType};
 
+/// Turn a failed `try_iter` into a clear message. Skipping the loop instead
+/// would write an empty file and report success.
+fn not_iterable(_: PyErr) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+        "records must be an iterable of dicts, a DataFrame, or an Arrow stream",
+    )
+}
+
 /// Write data to CSV (file path or buffer).
 ///
 /// When `sanitize_formulas` is `true`, string fields that begin with
@@ -78,23 +86,21 @@ pub fn write_csv(
         } else {
             // Pandas — iterate rows via `.values`
             let values = records.getattr(py, "values")?;
-            if let Ok(rows) = values.bind(py).try_iter() {
-                for row_res in rows {
-                    let row = row_res?;
-                    if let Ok(items) = row.try_iter() {
-                        let mut first = true;
-                        for item_res in items {
-                            let item = item_res?;
-                            if !first {
-                                output.push(delim_byte);
-                            }
-                            first = false;
-                            let mut sink = CsvCell::new(&mut output, sanitize_formulas);
-                            classify_and_write(&item, &mut sink)?;
-                        }
-                        output.push(b'\n');
+            // Propagate rather than skip: silently emitting an empty file is
+            // worse than saying the input could not be iterated.
+            for row_res in values.bind(py).try_iter()? {
+                let row = row_res?;
+                let mut first = true;
+                for item_res in row.try_iter()? {
+                    let item = item_res?;
+                    if !first {
+                        output.push(delim_byte);
                     }
+                    first = false;
+                    let mut sink = CsvCell::new(&mut output, sanitize_formulas);
+                    classify_and_write(&item, &mut sink)?;
                 }
+                output.push(b'\n');
             }
         }
     } else {
@@ -105,42 +111,43 @@ pub fn write_csv(
         let mut headers_written = false;
         let mut col_types: Vec<ColType> = Vec::new();
 
-        if let Ok(rows) = bound.try_iter() {
-            for row_res in rows {
-                let row_obj = row_res?;
-                let row_dict = row_obj.cast::<pyo3::types::PyDict>().map_err(|_| {
-                    PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        "Items in records must be dictionaries",
-                    )
-                })?;
+        let rows: pyo3::Bound<'_, pyo3::types::PyIterator> =
+            bound.try_iter().map_err(not_iterable)?;
+        for row_res in rows {
+            let row_obj = row_res?;
+            let row_dict = row_obj.cast::<pyo3::types::PyDict>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "Items in records must be dictionaries",
+                )
+            })?;
 
-                if !headers_written {
-                    for key in row_dict.keys().iter() {
-                        headers.push(key.extract::<String>()?);
-                    }
-                    write_csv_row_strings(&mut output, &headers, delim_byte, sanitize_formulas);
-                    col_types.resize(headers.len(), ColType::Unknown);
-                    headers_written = true;
+            if !headers_written {
+                for key in row_dict.keys().iter() {
+                    headers.push(key.extract::<String>()?);
                 }
-
-                // Iterate the dict directly (insertion order == header order)
-                // to avoid allocating a fresh `values()` list per row.
-                for (col, (_key, value)) in row_dict.iter().enumerate() {
-                    if col > 0 {
-                        output.push(delim_byte);
-                    }
-                    let cached = col_types.get(col).copied().unwrap_or(ColType::Unknown);
-                    let mut sink = CsvCell::new(&mut output, sanitize_formulas);
-                    if !try_cached(&value, cached, &mut sink)? {
-                        let detected = classify_and_write(&value, &mut sink)?;
-                        if col < col_types.len() && col_types[col] == ColType::Unknown {
-                            col_types[col] = detected;
-                        }
-                    }
-                }
-                output.push(b'\n');
+                write_csv_row_strings(&mut output, &headers, delim_byte, sanitize_formulas);
+                col_types.resize(headers.len(), ColType::Unknown);
+                headers_written = true;
             }
+
+            // Iterate the dict directly (insertion order == header order)
+            // to avoid allocating a fresh `values()` list per row.
+            for (col, (_key, value)) in row_dict.iter().enumerate() {
+                if col > 0 {
+                    output.push(delim_byte);
+                }
+                let cached = col_types.get(col).copied().unwrap_or(ColType::Unknown);
+                let mut sink = CsvCell::new(&mut output, sanitize_formulas);
+                if !try_cached(&value, cached, &mut sink)? {
+                    let detected = classify_and_write(&value, &mut sink)?;
+                    if col < col_types.len() && col_types[col] == ColType::Unknown {
+                        col_types[col] = detected;
+                    }
+                }
+            }
+            output.push(b'\n');
         }
+
     }
 
     write_bytes_to_target(py, &output, file_name)

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -339,121 +339,127 @@ fn write_worksheet_content(
         }
 
         WorksheetData::Records(records_list) => {
-            if let Ok(rows) = records_list.bind(py).try_iter() {
-                let mut headers: Vec<String> = Vec::new();
-                let mut headers_written = false;
-                let mut col_types: Vec<ColType> = Vec::new();
-                // Resolved once when headers are first seen; kept alive for the
-                // entire row loop so we can hand out &Format borrows per cell.
-                // `banded` is None unless the sheet asked for alternating rows.
-                let mut palettes: Option<(
-                    crate::format::RowPalette,
-                    Option<crate::format::RowPalette>,
-                )> = None;
-                let mut url_cols: Vec<bool> = Vec::new();
-                let mut n_data_cols: usize = 0;
+            // Propagate rather than skip: a non-iterable input used to
+            // produce an empty sheet and report success.
+            let rows = records_list.bind(py).try_iter().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "records must be an iterable of dicts, a DataFrame, or an Arrow stream",
+                )
+            })?;
+            let mut headers: Vec<String> = Vec::new();
+            let mut headers_written = false;
+            let mut col_types: Vec<ColType> = Vec::new();
+            // Resolved once when headers are first seen; kept alive for the
+            // entire row loop so we can hand out &Format borrows per cell.
+            // `banded` is None unless the sheet asked for alternating rows.
+            let mut palettes: Option<(
+                crate::format::RowPalette,
+                Option<crate::format::RowPalette>,
+            )> = None;
+            let mut url_cols: Vec<bool> = Vec::new();
+            let mut n_data_cols: usize = 0;
 
-                for (row_idx, row_res) in rows.enumerate() {
-                    let row_obj = row_res?;
-                    let row_dict = row_obj.cast::<pyo3::types::PyDict>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                            "Items in records must be dictionaries",
-                        )
-                    })?;
+            for (row_idx, row_res) in rows.enumerate() {
+                let row_obj = row_res?;
+                let row_dict = row_obj.cast::<pyo3::types::PyDict>().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                        "Items in records must be dictionaries",
+                    )
+                })?;
 
-                    if !headers_written {
-                        for key in row_dict.keys().iter() {
-                            headers.push(key.extract::<String>()?);
-                        }
-                        for fc in &formula_cols {
-                            headers.push(fc.header.clone());
-                        }
-                        write_all_headers(
-                            worksheet,
-                            header_row,
-                            &headers,
-                            bold_headers,
-                            &bold_fmt,
-                            index_columns,
-                            header_format.map(|h| &h.inner),
-                        )?;
-                        col_types.resize(headers.len(), ColType::Unknown);
-                        final_headers = headers.clone();
-                        n_data_cols = headers.len() - formula_cols.len();
-                        // Resolve per-column formats ONCE and keep them for the whole loop.
-                        // Apply set_column_format BEFORE writing data rows (constant memory mode).
-                        let col_formats =
-                            crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
-                        crate::format::apply_column_formats(worksheet, &col_formats)?;
-                        palettes = Some(crate::format::build_palettes(
-                            &col_formats,
-                            float_fmt.as_ref(),
-                            &datetime_fmt,
-                            layout.band_color.as_deref(),
-                        )?);
-                        url_cols =
-                            crate::helpers::resolve_url_columns(url_columns, &final_headers, py)?;
-                        headers_written = true;
+                if !headers_written {
+                    for key in row_dict.keys().iter() {
+                        headers.push(key.extract::<String>()?);
                     }
-
-                    let row_u32 = layout.first_data_row() + row_idx as u32;
-                    let (plain, banded) = palettes
-                        .as_ref()
-                        .expect("palettes are built with the header row");
-                    let pal = if layout.is_banded(row_u32) {
-                        banded.as_ref().unwrap_or(plain)
-                    } else {
-                        plain
-                    };
-                    // Everything but `col`/`col_override` is fixed for the row,
-                    // so build the sink once and step it across the columns
-                    // rather than reassembling all nine fields per cell.
-                    let mut sink = ExcelCell {
-                        worksheet: &mut *worksheet,
-                        row: row_u32,
-                        col: 0,
-                        text_fmt: pal.text.as_ref(),
-                        float_fmt: pal.float.as_ref(),
-                        datetime_fmt: &pal.datetime,
-                        datetime_cols_set: &mut datetime_cols_set,
-                        col_override: None,
-                        per_cell_datetime: banding,
-                        is_url: false,
-                    };
-
-                    // Iterate the dict directly (insertion order == header order)
-                    // to avoid allocating a fresh `values()` list per row.
-                    for (col, (_key, value)) in row_dict.iter().enumerate() {
-                        let cached = col_types
-                            .get(col)
-                            .copied()
-                            .unwrap_or(ColType::Unknown);
-
-                        sink.col = col as u16;
-                        // Column format override: wins over float_fmt / datetime_fmt.
-                        sink.col_override = pal.col(col);
-                        sink.is_url = url_cols.get(col).copied().unwrap_or(false);
-
-                        if !try_cached(&value, cached, &mut sink)? {
-                            let detected = classify_and_write(&value, &mut sink)?;
-                            if col < col_types.len() && col_types[col] == ColType::Unknown {
-                                col_types[col] = detected;
-                            }
-                        }
+                    for fc in &formula_cols {
+                        headers.push(fc.header.clone());
                     }
-                    if !formula_cols.is_empty() {
-                        crate::helpers::write_formula_row(
-                            worksheet,
-                            &formula_cols,
-                            n_data_cols as u16,
-                            row_u32,
-                            first_data_row,
-                            None,
-                        )?;
-                    }
-                    data_rows = row_idx as u32 + 1;
+                    write_all_headers(
+                        worksheet,
+                        header_row,
+                        &headers,
+                        bold_headers,
+                        &bold_fmt,
+                        index_columns,
+                        header_format.map(|h| &h.inner),
+                    )?;
+                    col_types.resize(headers.len(), ColType::Unknown);
+                    final_headers = headers.clone();
+                    n_data_cols = headers.len() - formula_cols.len();
+                    // Resolve per-column formats ONCE and keep them for the whole loop.
+                    // Apply set_column_format BEFORE writing data rows (constant memory mode).
+                    let col_formats =
+                        crate::format::resolve_column_formats(column_formats, &final_headers, py)?;
+                    crate::format::apply_column_formats(worksheet, &col_formats)?;
+                    palettes = Some(crate::format::build_palettes(
+                        &col_formats,
+                        float_fmt.as_ref(),
+                        &datetime_fmt,
+                        layout.band_color.as_deref(),
+                    )?);
+                    url_cols =
+                        crate::helpers::resolve_url_columns(url_columns, &final_headers, py)?;
+                    headers_written = true;
                 }
+
+                let row_u32 = layout.first_data_row() + row_idx as u32;
+                let (plain, banded) = palettes
+                    .as_ref()
+                    .expect("palettes are built with the header row");
+                let pal = if layout.is_banded(row_u32) {
+                    banded.as_ref().unwrap_or(plain)
+                } else {
+                    plain
+                };
+                // Everything but `col`/`col_override` is fixed for the row,
+                // so build the sink once and step it across the columns
+                // rather than reassembling all nine fields per cell.
+                let mut sink = ExcelCell {
+                    worksheet: &mut *worksheet,
+                    row: row_u32,
+                    col: 0,
+                    text_fmt: pal.text.as_ref(),
+                    float_fmt: pal.float.as_ref(),
+                    datetime_fmt: &pal.datetime,
+                    datetime_cols_set: &mut datetime_cols_set,
+                    col_override: None,
+                    per_cell_datetime: banding,
+                    is_url: false,
+                };
+
+                // Iterate the dict directly (insertion order == header order)
+                // to avoid allocating a fresh `values()` list per row.
+                for (col, (_key, value)) in row_dict.iter().enumerate() {
+                    let cached = col_types
+                        .get(col)
+                        .copied()
+                        .unwrap_or(ColType::Unknown);
+
+                    sink.col = col as u16;
+                    // Column format override: wins over float_fmt / datetime_fmt.
+                    sink.col_override = pal.col(col);
+                    sink.is_url = url_cols.get(col).copied().unwrap_or(false);
+
+                    if !try_cached(&value, cached, &mut sink)? {
+                        let detected = classify_and_write(&value, &mut sink)?;
+                        if col < col_types.len() && col_types[col] == ColType::Unknown {
+                            col_types[col] = detected;
+                        }
+                    }
+                }
+                if !formula_cols.is_empty() {
+                    crate::helpers::write_formula_row(
+                        worksheet,
+                        &formula_cols,
+                        n_data_cols as u16,
+                        row_u32,
+                        first_data_row,
+                        None,
+                    )?;
+                }
+                data_rows = row_idx as u32 + 1;
             }
+
         }
 
         WorksheetData::PandasDataFrame(df) => {

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -224,9 +224,17 @@ fn write_worksheet_content(
 
     match records {
         WorksheetData::ArrowDataFrame(stream_obj) => {
-            let arrow_ok = (|| -> PyResult<()> {
-                let reader = crate::arrow_ffi::stream_to_reader(stream_obj, py)?;
-
+            // Producing the stream can fail even though the object advertises
+            // `__arrow_c_stream__` — pandas raises ImportError when pyarrow is
+            // not installed, and an all-Null empty frame has no Arrow type. The
+            // reader is therefore built up front: while nothing has been
+            // written yet, falling back to the column-by-column writer is safe.
+            // Once batches start landing a failure has to propagate, because
+            // re-writing from the top would duplicate rows.
+            let reader = crate::arrow_ffi::stream_to_reader(stream_obj, py);
+            let arrow_ok = match reader {
+                Err(stream_err) => Err(stream_err),
+                Ok(reader) => (|| -> PyResult<()> {
                 let schema = reader.schema();
                 final_headers = schema
                     .fields()
@@ -295,21 +303,36 @@ fn write_worksheet_content(
                 }
                 data_rows = current_row - layout.first_data_row();
                 Ok(())
-            })();
+                })(),
+            };
 
-            // If Arrow FFI failed (e.g. Null-typed empty DataFrame), at
-            // least write the header row from `.columns`.
-            if arrow_ok.is_err() {
-                if let Ok(cols) = stream_obj.getattr(py, "columns") {
-                    final_headers = cols.extract(py).unwrap_or_default();
-                    write_all_headers(
-                        worksheet,
-                        header_row,
-                        &final_headers,
-                        bold_headers,
-                        &bold_fmt,
-                        index_columns,
-                        header_format.map(|h| &h.inner),
+            if let Err(stream_err) = arrow_ok {
+                let df = stream_obj.bind(py);
+                // Polars exposes `get_column`; pandas indexes with `[]`.
+                let polars = df.hasattr("get_column")?;
+                if !df.hasattr("columns")? || !df.hasattr("dtypes")? {
+                    return Err(stream_err);
+                }
+                if polars {
+                    write_dataframe(
+                        worksheet, py, stream_obj, &mut final_headers, &mut data_rows,
+                        column_formats, float_fmt.as_ref(), &datetime_fmt,
+                        &mut datetime_cols_set, bold_headers, &bold_fmt, index_columns,
+                        header_format, layout, url_columns, &formula_cols,
+                        "get_column", "to_list",
+                        |dtype| Ok(polars_kind(&dtype.to_string())),
+                    )?;
+                } else {
+                    write_dataframe(
+                        worksheet, py, stream_obj, &mut final_headers, &mut data_rows,
+                        column_formats, float_fmt.as_ref(), &datetime_fmt,
+                        &mut datetime_cols_set, bold_headers, &bold_fmt, index_columns,
+                        header_format, layout, url_columns, &formula_cols,
+                        "__getitem__", "tolist",
+                        |dtype| {
+                            let kind: String = dtype.getattr("kind")?.extract()?;
+                            Ok(map_pandas_kind(kind.chars().next().unwrap_or('O')))
+                        },
                     )?;
                 }
             }

--- a/tests/test_arrow_fallback.py
+++ b/tests/test_arrow_fallback.py
@@ -148,3 +148,43 @@ def test_real_dataframes_still_take_the_arrow_path(tmp_path):
     ws = openpyxl.load_workbook(path).active
     assert ws.max_row == 4
     assert [c.value for c in ws[2]] == ["a", 1.5, 1]
+
+
+# --- input that cannot be iterated at all ---------------------------------
+# Same failure shape as the Arrow one: the loop used to be skipped on error,
+# leaving an empty file and a successful return.
+
+
+class _NotIterable:
+    pass
+
+
+@pytest.mark.parametrize(
+    "data", [42, None, _NotIterable(), 3.5], ids=["int", "none", "object", "float"]
+)
+def test_non_iterable_input_raises(tmp_path, data):
+    from rustpy_xlsxwriter import write_csv
+
+    for writer, suffix in ((write_worksheet, ".xlsx"), (write_csv, ".csv")):
+        path = tmp_path / f"bad{suffix}"
+        with pytest.raises(TypeError, match="must be an iterable of dicts"):
+            writer(data, str(path))
+
+
+def test_iterable_of_non_dicts_still_names_the_real_problem(tmp_path):
+    """A set is iterable, so it must fail on the items, not on iteration."""
+    with pytest.raises(TypeError, match="must be dictionaries"):
+        write_worksheet({1, 2, 3}, str(tmp_path / "bad.xlsx"))
+
+
+def test_empty_input_is_still_valid(tmp_path):
+    """An empty list is not an error — it just has no rows."""
+    path = tmp_path / "empty.xlsx"
+    write_worksheet([], str(path))
+    assert openpyxl.load_workbook(path).active.max_row == 1
+
+
+def test_generator_input_is_still_accepted(tmp_path):
+    path = tmp_path / "gen.xlsx"
+    write_worksheet((r for r in [{"a": 1}, {"a": 2}]), str(path))
+    assert openpyxl.load_workbook(path).active.max_row == 3

--- a/tests/test_arrow_fallback.py
+++ b/tests/test_arrow_fallback.py
@@ -1,0 +1,150 @@
+"""What happens when a DataFrame advertises Arrow but cannot deliver it.
+
+pandas 3 always exposes ``__arrow_c_stream__``, but calling it raises
+``ImportError`` when pyarrow is not installed — a very common setup, since
+pyarrow is an optional pandas dependency. That used to produce a file with
+only the header row: no rows, no error, no warning.
+
+The stubs here fail the same way without needing pyarrow to be absent, so the
+regression stays covered wherever the suite runs.
+"""
+
+import datetime
+
+import openpyxl
+import pytest
+
+from rustpy_xlsxwriter import FastExcel, write_worksheet
+
+
+class _Series:
+    def __init__(self, values):
+        self._values = values
+
+    def tolist(self):
+        return list(self._values)
+
+    to_list = tolist
+
+
+class _Dtype:
+    def __init__(self, kind):
+        self.kind = kind
+
+    def __str__(self):
+        return {"i": "Int64", "f": "Float64", "O": "String", "M": "Datetime"}[self.kind]
+
+
+class _BrokenArrowFrame:
+    """Pandas-shaped, and its Arrow stream raises like pandas without pyarrow."""
+
+    def __init__(self, data, kinds):
+        self._data = data
+        self.columns = list(data)
+        self.dtypes = [_Dtype(k) for k in kinds]
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        raise ImportError("`Import pyarrow` failed.  Use pip or conda to install")
+
+    def __len__(self):
+        return len(next(iter(self._data.values())))
+
+    def __getitem__(self, key):
+        return _Series(self._data[key])
+
+
+class _BrokenArrowPolarsFrame(_BrokenArrowFrame):
+    """Same, but with the Polars accessor so the other branch is exercised."""
+
+    columns: list
+
+    def get_column(self, name):
+        return _Series(self._data[name])
+
+    def __getitem__(self, key):  # pragma: no cover - must not be reached
+        raise AssertionError("polars frames must go through get_column")
+
+
+DATA = {
+    "name": ["a", "b", "c"],
+    "score": [1.5, 2.5, 3.5],
+    "count": [1, 2, 3],
+}
+KINDS = ["O", "f", "i"]
+
+
+@pytest.mark.parametrize(
+    "frame_cls", [_BrokenArrowFrame, _BrokenArrowPolarsFrame], ids=["pandas", "polars"]
+)
+def test_rows_are_written_when_the_arrow_stream_fails(tmp_path, frame_cls):
+    """The regression: this used to write the header and drop every row."""
+    path = tmp_path / "fallback.xlsx"
+    write_worksheet(frame_cls(DATA, KINDS), str(path))
+
+    ws = openpyxl.load_workbook(path).active
+    assert [c.value for c in ws[1]] == ["name", "score", "count"]
+    assert [c.value for c in ws[2]] == ["a", 1.5, 1]
+    assert [c.value for c in ws[4]] == ["c", 3.5, 3]
+    assert ws.max_row == 4
+
+
+def test_fallback_honours_formatting_options(tmp_path):
+    """It goes through the normal writer, so the options still apply."""
+    path = tmp_path / "styled.xlsx"
+    write_worksheet(
+        _BrokenArrowFrame(DATA, KINDS),
+        str(path),
+        float_format="0.00",
+        banded_rows="#F2F2F2",
+        autofilter=True,
+        totals_row={"count": "sum"},
+    )
+
+    ws = openpyxl.load_workbook(path).active
+    assert ws.cell(row=2, column=2).number_format == "0.00"
+    assert ws.cell(row=3, column=1).fill.fgColor.rgb == "FFF2F2F2"
+    assert ws.auto_filter.ref == "A1:C4"
+    assert ws["C5"].value == "=SUM(C2:C4)"
+
+
+def test_fallback_handles_datetimes(tmp_path):
+    path = tmp_path / "dates.xlsx"
+    frame = _BrokenArrowFrame(
+        {"when": [datetime.datetime(2026, 1, d) for d in (1, 2)]}, ["M"]
+    )
+    write_worksheet(frame, str(path))
+
+    ws = openpyxl.load_workbook(path).active
+    assert ws["A2"].value == datetime.datetime(2026, 1, 1)
+    assert ws["A3"].value == datetime.datetime(2026, 1, 2)
+
+
+def test_fallback_through_the_builder(tmp_path):
+    path = tmp_path / "builder.xlsx"
+    FastExcel(str(path)).sheet("S", _BrokenArrowFrame(DATA, KINDS)).save()
+    assert openpyxl.load_workbook(path)["S"].max_row == 4
+
+
+class _NotAFrame:
+    """Advertises the stream but is not tabular — nothing to fall back to."""
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        raise ImportError("no pyarrow")
+
+
+def test_unusable_object_raises_the_original_error(tmp_path):
+    """Better a clear failure than a silently empty file."""
+    with pytest.raises(Exception, match="pyarrow"):
+        write_worksheet(_NotAFrame(), str(tmp_path / "bad.xlsx"))
+
+
+def test_real_dataframes_still_take_the_arrow_path(tmp_path):
+    """The fallback must not shadow the fast path when Arrow works."""
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
+    path = tmp_path / "arrow.xlsx"
+    write_worksheet(pd.DataFrame(DATA), str(path))
+
+    ws = openpyxl.load_workbook(path).active
+    assert ws.max_row == 4
+    assert [c.value for c in ws[2]] == ["a", 1.5, 1]


### PR DESCRIPTION
Two bugs where a write succeeded and produced a file with no data, plus free-threaded Python support made real.

## 1. A DataFrame wrote only its header when Arrow was unavailable

pandas 3 always exposes `__arrow_c_stream__`, but calling it raises `ImportError` without pyarrow — an optional pandas dependency, so a very common setup. The failure was caught and answered by writing the header row from `.columns`:

```
without pyarrow:  5,168 bytes for a 200k-row frame, no error, no warning
with pyarrow:     2,803,592 bytes
```

The reader is now built before the write closure. While nothing has been written yet a fallback is safe, so the column-by-column writer takes over and produces the full sheet with all formatting options intact. A failure *after* batches have landed now propagates instead — re-writing from the top would duplicate rows, and those errors were being swallowed too.

An object that advertises the stream but is not tabular raises the original error rather than yielding an empty file.

Tests use a stub whose `__arrow_c_stream__` raises, so the regression stays covered whether or not pyarrow is installed. That is why it went unnoticed: `pyarrow` is in `requirements.txt`, so the suite never took that path.

## 2. Non-iterable input produced an empty file and returned successfully

Three sites shared the same shape — `if let Ok(rows) = try_iter()` skipped the loop on failure:

```python
write_worksheet(42, "out.xlsx")   # valid, empty .xlsx, returned fine
write_csv(None, "out.csv")        # empty .csv, returned fine
```

Both now raise `TypeError: records must be an iterable of dicts, a DataFrame, or an Arrow stream`. A `set` still fails on its *items* (`must be dictionaries`) rather than on iteration, since a set is iterable and the message has to point at the real problem. Empty lists and generators keep working.

## 3. cp314t wheels

The existing jobs pass `--find-interpreter`, which only sees interpreters installed on the runner. A free-threaded build is a separate binary (`python3.14t`), so no cp314t wheel was ever produced — while `pyproject.toml` already advertises Python 3.14. Users on a free-threaded build fell through to the sdist and needed a Rust toolchain.

Verified on a real 3.14t build before writing the job: the wheel tags as `cp314-cp314t`, the suite passes on it (303 passed; Polars skipped, it has no free-threaded wheel yet), and a stress run came back clean — 32 parallel writes, a shared `Format`, and a `Format` mutated by one thread while eight others wrote with it. Stress testing cannot *prove* the absence of races, only fail to find them.

Worth knowing: PyO3 0.29 emits `Py_MOD_GIL_NOT_USED` **by default**, so the library has been advertising free-threading support all along. No code change was needed — the promise simply had never been checked.

Scoped to the platforms free-threading is actually run on. `fail-fast: false` so one missing interpreter cannot hide the rest. **I could not verify the job itself runs on GitHub Actions** — the linux leg in particular depends on `python3.14t` being reachable inside the manylinux container. The first CI run is the test; if it fails, the fix is likely an explicit `/opt/python/cp314-cp314t/bin/python`.

## 4. Concurrency benchmark and docs

`python benchmark.py --concurrent` writes the same 1M records across 1/2/4/8 workers, measuring **both** writers at each count:

| Workers | RustPy | xlsxwriter | Speedup |
|---|---|---|---|
| 1 | 5.40s | 43.47s | 8.0x |
| 8 | 5.69s | 39.55s | 6.9x |

*Python 3.14, standard build — flat, the GIL serialises both.*

| Workers | RustPy | xlsxwriter | Speedup |
|---|---|---|---|
| 1 | 6.10s | 45.00s | 7.4x |
| 8 | **1.72s** | 16.21s | **9.4x** |

*Python 3.14t, free-threaded.*

Measuring xlsxwriter at every worker count was the point. It is pure Python, so on a free-threaded build it spreads across threads too — 45.00s to 16.21s, 2.8x. Comparing a parallel RustPy run against a single-threaded baseline would have claimed **26x**. The honest figure is that RustPy scales further, 3.5x against 2.8x, so the advantage widens from 7.4x to 9.4x rather than exploding.

The cost is stated too: a single write is ~10% slower on 3.14t. One big export favours the standard build; many concurrent exports favour the free-threaded one.

`pandas` and `polars` are now imported lazily in `benchmark.py` — Polars has no free-threaded wheel, and importing it eagerly stopped `--concurrent` from running on the one interpreter it exists for.

## Verification

```
cargo build --release            → OK
cargo clippy --release           → 14 warnings, same as master (none new)
pytest tests/ -m "not benchmark" → 348 passed (14 new)
on python3.14t                   → 303 passed (Polars unavailable)
```

Version bumped to **0.6.1** (patch — no public API changes). 0.6.0 is already tagged, so this work needs its own number.
